### PR TITLE
Implement hub and agent as independent components

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -102,6 +102,11 @@ export class MachineAgent {
     }
     for (const [, session] of this.sessions) {
       session.abortController.abort();
+      // Reject any pending prompt promises so canUseTool doesn't hang
+      for (const [, resolver] of session.pendingPrompts) {
+        resolver({ kind: "deny", message: "Agent disconnected" });
+      }
+      session.pendingPrompts.clear();
     }
     this.sessions.clear();
     if (this.ws) {

--- a/hub/src/hub.ts
+++ b/hub/src/hub.ts
@@ -41,6 +41,8 @@ export class Hub {
   config: HubConfig;
   clients: Map<string, ClientConnection>;
   agents: Map<string, AgentConnection>;
+  /** Maps requestId -> ClientConnection for pending history requests */
+  pendingHistoryRequests: Map<string, ClientConnection>;
   httpServer: ReturnType<typeof createServer>;
   wss: WebSocketServer;
 
@@ -48,6 +50,7 @@ export class Hub {
     this.config = config;
     this.clients = new Map();
     this.agents = new Map();
+    this.pendingHistoryRequests = new Map();
 
     this.httpServer = createServer((req, res) => this.handleHttp(req, res));
     this.wss = new WebSocketServer({ server: this.httpServer });
@@ -309,6 +312,7 @@ export class Hub {
     const result = this.resolveSessionAgent(conn, msg.sessionId);
     if (!result) return;
     const requestId = randomUUID();
+    this.pendingHistoryRequests.set(requestId, conn);
     this.sendToAgent(result.agentConn, {
       type: "hub_get_history",
       sessionId: msg.sessionId,
@@ -393,9 +397,19 @@ export class Hub {
       case "tool_call":
       case "tool_result":
       case "user_prompt":
-      case "session_history":
         this.relayToClients(conn.accountId, msg);
         break;
+
+      case "session_history": {
+        const requestingClient = this.pendingHistoryRequests.get(msg.requestId);
+        this.pendingHistoryRequests.delete(msg.requestId);
+        if (requestingClient) {
+          this.sendToClient(requestingClient, msg);
+        } else {
+          this.relayToClients(conn.accountId, msg);
+        }
+        break;
+      }
 
       case "session_status":
         this.config.db.updateSessionStatus(


### PR DESCRIPTION
## Summary

- **Hub** (`hub/`): Standalone Node.js server with WebSocket routing, SQLite DB, JWT auth, REST auth endpoints, runtime message validation, account isolation
- **Agent** (`agent/`): Standalone Node.js agent with Claude SDK integration, session streaming, AskUserQuestion relay, session history for completed sessions
- Both components are fully independent (own package.json, tests, no shared code)
- 51 tests total (44 hub + 7 agent), all passing

## Issues fixed from previous review

- Added REST auth endpoints (`/api/auth/register`, `/api/auth/login`, `/api/auth/refresh`) -- clients can now get tokens
- Added runtime message validation (required field checks per message type)
- Fixed session history for completed sessions (sdkSessionIds map persists across session cleanup)
- Eliminated shared package -- each component defines its own protocol types

## Test plan

- [x] Hub: 44 tests pass (`cd hub && npm test`)
- [x] Agent: 7 tests pass (`cd agent && npm test`)
- [x] Both type-check independently (`npm run typecheck`)
- [x] No cross-dependencies (`grep -r "@cc-commander" hub/ agent/` finds nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)