### PR TITLE
release: fix tag-list parsing in verify step + expose VERSION via compose env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,11 @@ jobs:
       # update flow silently breaks because /api/version returns "".
       - name: Verify VERSION baked into image
         run: |
-          IMG="$(echo '${{ steps.meta.outputs.tags }}' | head -n1)"
+          # docker/metadata-action emits tags either newline- or
+          # comma-separated depending on version. Normalise both into
+          # newlines and pick the first non-empty entry.
+          IMG="$(printf '%s' '${{ steps.meta.outputs.tags }}' | tr ',' '\n' | sed '/^$/d' | head -n1)"
+          echo "Verifying $IMG"
           docker pull "$IMG"
           BAKED="$(docker run --rm --entrypoint sh "$IMG" -c 'printf %s "$VERSION"')"
           EXPECTED='${{ steps.meta.outputs.version }}'

--- a/hub/docker-compose.yml
+++ b/hub/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       PORT: "3000"
       HUB_DB_PATH: /data/hub.db
+      # Optional. When building locally (not via CI), set VERSION in
+      # .env to the git SHA so runners can self-update against this
+      # hub. CI builds bake VERSION via the Dockerfile ARG instead and
+      # this passthrough is a no-op.
+      VERSION: ${VERSION:-}
     volumes:
       - hub-data:/data
 


### PR DESCRIPTION
## Summary

Two small follow-ups discovered while deploying the hub manually to a VPS today.

**1. `release.yml` verify step crashes on multi-tag images.**

```yaml
IMG="$(echo '${{ steps.meta.outputs.tags }}' | head -n1)"
```

`docker/metadata-action` emits tags either newline- or comma-separated depending on version. With the comma format, `head -n1` returns the entire single line and `docker pull` then chokes on the literal comma (`invalid reference format`). Both Release runs after EliasSchlie/cc-commander#25 failed at this step → no GHCR image was published, so `docker compose pull` deploys aren't possible.

Fix: normalise commas to newlines, drop empty lines, take the first.

**2. `hub/docker-compose.yml` only baked `VERSION` at build time.**

A manual local build (`docker compose build` without `--build-arg VERSION=...`) produced an image where `/api/version` returned `""`, which silently disables runner self-update.

Fix: add a `VERSION: ${VERSION:-}` environment passthrough so operators doing a local build can set `VERSION=$(git rev-parse HEAD)` in `hub/.env` and have it surface at runtime. CI builds keep using the Dockerfile `ARG` and this passthrough is a no-op for them.

## Test plan
- [ ] CI Release run on this branch should succeed (it'll exercise the fixed verify step on a `:sha-...,:main` tag list).
- [x] Manual local repro: `docker compose build && VERSION=$(git rev-parse HEAD) docker compose up -d` then `curl /api/version` returns the SHA. Done on a real VPS deploy today.

## Context
Discovered during the live VPS deployment of `cc-commander.eliasschlie.com`. Without these fixes the operator workflow is "rebuild Docker locally with `--build-arg`" instead of "`docker compose pull`", and runners on misconfigured hubs silently stop auto-updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)