### PR TITLE
fix(hub): emit ISO8601 timestamps so macOS client can decode machine_list

### DIFF
--- a/hub/src/__tests__/db.test.ts
+++ b/hub/src/__tests__/db.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { HubDb } from "../db.ts";
+import { HubDb, sqliteToIso8601 } from "../db.ts";
+
+const ISO8601_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
 
 let db: HubDb;
 
@@ -158,5 +160,60 @@ describe("refresh tokens", () => {
     const token = db.createRefreshToken(account.id, "2030-01-01T00:00:00Z");
     db.deleteRefreshToken(token);
     assert.equal(db.getRefreshToken(token), undefined);
+  });
+});
+
+describe("ISO8601 timestamp wire format", () => {
+  // Prevents: SQLite's default `YYYY-MM-DD HH:MM:SS` format leaking into
+  // JSON broadcasts. Swift's JSONDecoder.dateDecodingStrategy = .iso8601
+  // can't parse the SQLite shape and silently drops the entire enclosing
+  // message, which manifests as "no machines online" in the macOS app.
+  it("sqliteToIso8601 converts SQLite datetime format to ISO8601", () => {
+    assert.equal(
+      sqliteToIso8601("2026-04-07 10:56:55"),
+      "2026-04-07T10:56:55Z",
+    );
+  });
+
+  // Prevents: future schema migration to ISO-native breaking the converter
+  it("sqliteToIso8601 is idempotent for already-ISO8601 input", () => {
+    assert.equal(
+      sqliteToIso8601("2026-04-07T10:56:55Z"),
+      "2026-04-07T10:56:55Z",
+    );
+  });
+
+  it("sqliteToIso8601 passes through empty/null input", () => {
+    assert.equal(sqliteToIso8601(""), "");
+  });
+
+  // Prevents: regression where listMachinesForAccount emits SQLite format
+  it("listMachinesForAccount emits ISO8601 lastSeen", () => {
+    const account = db.createAccount("test@example.com", "hash");
+    db.createMachine(account.id, "Test Machine");
+    const machines = db.listMachinesForAccount(account.id);
+    assert.equal(machines.length, 1);
+    assert.match(machines[0].lastSeen, ISO8601_RE);
+  });
+
+  // Prevents: regression where listSessionsForAccount emits SQLite format
+  it("listSessionsForAccount emits ISO8601 lastActivity and createdAt", () => {
+    const account = db.createAccount("test@example.com", "hash");
+    const machine = db.createMachine(account.id, "Test");
+    db.createSession(account.id, machine.id, "/tmp", "idle");
+    const sessions = db.listSessionsForAccount(account.id);
+    assert.equal(sessions.length, 1);
+    assert.match(sessions[0].lastActivity, ISO8601_RE);
+    assert.match(sessions[0].createdAt, ISO8601_RE);
+  });
+
+  // Prevents: regression where getMachineByToken emits SQLite format
+  it("getMachineByToken emits ISO8601 lastSeen and createdAt", () => {
+    const account = db.createAccount("test@example.com", "hash");
+    const machine = db.createMachine(account.id, "Test");
+    const found = db.getMachineByToken(machine.registrationToken);
+    assert.ok(found);
+    assert.match(found.lastSeen, ISO8601_RE);
+    assert.match(found.createdAt, ISO8601_RE);
   });
 });

--- a/hub/src/db.ts
+++ b/hub/src/db.ts
@@ -152,7 +152,7 @@ export class HubDb {
       machineId: r.id,
       name: r.name,
       online: false,
-      lastSeen: r.last_seen,
+      lastSeen: sqliteToIso8601(r.last_seen),
     }));
   }
 
@@ -200,9 +200,9 @@ export class HubDb {
       machineId: r.machine_id,
       directory: r.directory,
       status: r.status,
-      lastActivity: r.last_activity,
+      lastActivity: sqliteToIso8601(r.last_activity),
       lastMessagePreview: r.last_message_preview,
-      createdAt: r.created_at,
+      createdAt: sqliteToIso8601(r.created_at),
     }));
   }
 
@@ -283,12 +283,29 @@ export class HubDb {
   }
 }
 
+/**
+ * SQLite's `datetime('now')` returns timestamps as `YYYY-MM-DD HH:MM:SS`
+ * (no T separator, no zone). Clients expect ISO8601 (`YYYY-MM-DDTHH:MM:SSZ`)
+ * because `JSONDecoder.dateDecodingStrategy = .iso8601` on Swift can't parse
+ * the SQLite shape and silently drops the entire enclosing message. Convert
+ * here so the SQLite format never leaks over the wire.
+ *
+ * Idempotent: if the input already looks ISO8601 it is returned unchanged,
+ * which lets the function tolerate future schema migrations that store
+ * timestamps in ISO format directly.
+ */
+export function sqliteToIso8601(s: string): string {
+  if (!s) return s;
+  if (s.includes("T")) return s; // already ISO8601
+  return s.replace(" ", "T") + "Z";
+}
+
 function toAccountRow(row: any): AccountRow {
   return {
     id: row.id,
     email: row.email,
     passwordHash: row.password_hash,
-    createdAt: row.created_at,
+    createdAt: sqliteToIso8601(row.created_at),
   };
 }
 
@@ -298,8 +315,8 @@ function toMachineRow(row: any): MachineRow {
     accountId: row.account_id,
     name: row.name,
     registrationToken: row.registration_token,
-    lastSeen: row.last_seen,
-    createdAt: row.created_at,
+    lastSeen: sqliteToIso8601(row.last_seen),
+    createdAt: sqliteToIso8601(row.created_at),
   };
 }
 
@@ -310,9 +327,9 @@ function toSessionRow(row: any): SessionRow {
     machineId: row.machine_id,
     directory: row.directory,
     status: row.status,
-    lastActivity: row.last_activity,
+    lastActivity: sqliteToIso8601(row.last_activity),
     lastMessagePreview: row.last_message_preview,
     sdkSessionId: row.sdk_session_id,
-    createdAt: row.created_at,
+    createdAt: sqliteToIso8601(row.created_at),
   };
 }


### PR DESCRIPTION
## Summary

Found while doing the first end-to-end test of the deployed hub. Symptom: log in to the macOS app, see "no machines online" even though the runner is connected to the hub and a shadow Python WebSocket client receives \`machine_list\` correctly.

**Root cause:** SQLite's \`datetime('now')\` returns timestamps as \`YYYY-MM-DD HH:MM:SS\` (no T separator, no zone). \`hub/src/db.ts\` was passing these straight through to JSON. The macOS client uses \`JSONDecoder.dateDecodingStrategy = .iso8601\` (\`client/swift/CCCommanderPackage/Sources/CCNetworking/WebSocketClient.swift:14\`), which can't parse the SQLite shape and silently drops the entire enclosing message. Result: app logs in fine but never sees any \`machine_list\` or \`session_list\` payload.

This is the protocol-drift risk my earlier review (#35 commentary) flagged but didn't catch as load-bearing — the Swift fields are typed \`Date\` while the hub fields are typed \`string\`, and the format the hub actually emits isn't ISO8601 in either direction.

## Fix

\`hub/src/db.ts\`: convert SQLite-shaped timestamps to ISO8601 in the row→object converters before any row escapes the persistence layer. Single \`sqliteToIso8601\` helper, idempotent so a future schema migration to ISO-native timestamps doesn't need to revisit it.

Touch points: \`toAccountRow\`, \`toMachineRow\`, \`toSessionRow\`, \`listMachinesForAccount\`, \`listSessionsForAccount\`.

## Test plan

- [x] Unit tests for the helper (round-trip + idempotency + empty input)
- [x] Regression tests asserting \`listMachinesForAccount\`, \`listSessionsForAccount\`, \`getMachineByToken\` emit ISO8601
- [x] Full hub suite: \`npm test\` → 65 → 71 tests, all green
- [x] \`npm run typecheck\` clean
- [ ] Manual end-to-end on the live deployed hub: redeploy, log in via macOS app, verify machine list populates. Will do after merge.

## Note on conflicts with other open PRs

This PR only touches \`hub/src/db.ts\` and \`hub/src/__tests__/db.test.ts\`. None of the other open PRs (#36, #37, #38, #39, #40) touch these files, so no conflict expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)