### PR TITLE
hub/runner: structured-JSON metric counters (#44 A3)

### DIFF
--- a/hub/src/__tests__/hub.test.ts
+++ b/hub/src/__tests__/hub.test.ts
@@ -722,6 +722,186 @@ describe("pending history cleanup", () => {
   });
 });
 
+// ── Metrics integration ───────────────────────────────────────────────
+//
+// Verifies the four hub-side counter sites land in the Metrics snapshot
+// with the expected labels. The Metrics class itself is unit-tested in
+// the protocol package.
+describe("metrics counters", () => {
+  // Prevents: a misbehaving client crashing the parser without anyone
+  // noticing the rate at which it happens.
+  it("counts hub.parse_reject for malformed client messages", async () => {
+    const tokens = await auth.register("user@test.com", "pass");
+    const clientWs = await connectClient(tokens.token);
+    await new Promise((r) => setTimeout(r, 50));
+
+    clientWs.send("not json");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const snap = hub.metrics.snapshot();
+    assert.equal(snap["hub.parse_reject{source=client}"], 1);
+
+    await closeWs(clientWs);
+  });
+
+  it("counts hub.parse_reject for malformed runner messages", async () => {
+    const tokens = await auth.register("user@test.com", "pass");
+    const account = db.getAccountByEmail("user@test.com")!;
+    const machine = db.createMachine(account.id, "m");
+    const runnerWs = await connectRunner(machine.registrationToken);
+    void tokens;
+    await new Promise((r) => setTimeout(r, 50));
+
+    runnerWs.send("not json");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const snap = hub.metrics.snapshot();
+    assert.equal(snap["hub.parse_reject{source=runner}"], 1);
+
+    await closeWs(runnerWs);
+  });
+
+  it("counts hub.history_ttl_expired when the TTL fires", async () => {
+    await hub.stop();
+    db.close();
+    db = new HubDb(":memory:");
+    auth = new AuthService(db, JWT_SECRET);
+    hub = new Hub({ port: 0, db, auth, historyRequestTtlMs: 50 });
+    await hub.start();
+    const addr = hub.httpServer.address();
+    port = typeof addr === "object" && addr ? addr.port : 0;
+    baseUrl = `http://localhost:${port}`;
+
+    const tokens = await auth.register("u@test.com", "pw");
+    const account = db.getAccountByEmail("u@test.com")!;
+    const machine = db.createMachine(account.id, "m");
+    const session = db.createSession(account.id, machine.id, "/tmp", "idle");
+
+    const runnerWs = await connectRunner(machine.registrationToken);
+    const clientWs = await connectClient(tokens.token);
+    await new Promise((r) => setTimeout(r, 100));
+    runnerWs.on("message", () => {}); // swallow, force TTL
+
+    const replied = waitForMsg(clientWs, (m) => m.type === "session_history");
+    send(clientWs, { type: "get_session_history", sessionId: session.id });
+    await replied;
+
+    assert.equal(hub.metrics.snapshot()["hub.history_ttl_expired"], 1);
+
+    await closeWs(clientWs);
+    await closeWs(runnerWs);
+  });
+
+  // Both branches of orphan: unknown requestId and machineId mismatch.
+  it("counts hub.history_orphan_reply for unknown requestId", async () => {
+    const tokens = await auth.register("u@test.com", "pw");
+    const account = db.getAccountByEmail("u@test.com")!;
+    const machine = db.createMachine(account.id, "m");
+    const runnerWs = await connectRunner(machine.registrationToken);
+    void tokens;
+    await new Promise((r) => setTimeout(r, 50));
+
+    runnerWs.send(
+      JSON.stringify({
+        type: "session_history",
+        sessionId: "s1",
+        requestId: "never-pending",
+        messages: [],
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    assert.equal(hub.metrics.snapshot()["hub.history_orphan_reply"], 1);
+    await closeWs(runnerWs);
+  });
+
+  // A degraded reply (runner sets `error: fetch_failed` etc) is a
+  // distinct signal from an orphan reply -- operators want both rates.
+  // The closed-set label keeps cardinality bounded.
+  it("counts hub.history_degraded when reply carries an error code", async () => {
+    const tokens = await auth.register("u@test.com", "pw");
+    const account = db.getAccountByEmail("u@test.com")!;
+    const machine = db.createMachine(account.id, "m");
+    const session = db.createSession(account.id, machine.id, "/tmp", "idle");
+
+    const runnerWs = await connectRunner(machine.registrationToken);
+    const clientWs = await connectClient(tokens.token);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Capture the requestId the hub generated, then reply degraded.
+    const replyWhenAsked = new Promise<void>((resolve) => {
+      runnerWs.once("message", (data) => {
+        const msg = JSON.parse(data.toString());
+        runnerWs.send(
+          JSON.stringify({
+            type: "session_history",
+            sessionId: session.id,
+            requestId: msg.requestId,
+            messages: [],
+            error: "fetch_failed",
+          }),
+        );
+        resolve();
+      });
+    });
+
+    const clientGotReply = waitForMsg(
+      clientWs,
+      (m) => m.type === "session_history",
+    );
+    send(clientWs, { type: "get_session_history", sessionId: session.id });
+    await replyWhenAsked;
+    await clientGotReply;
+
+    const snap = hub.metrics.snapshot();
+    assert.equal(snap["hub.history_degraded{code=fetch_failed}"], 1);
+
+    await closeWs(clientWs);
+    await closeWs(runnerWs);
+  });
+
+  it("counts hub.dropped_tool_block with closed-set labels", async () => {
+    const tokens = await auth.register("u@test.com", "pw");
+    const account = db.getAccountByEmail("u@test.com")!;
+    const machine = db.createMachine(account.id, "m");
+    const runnerWs = await connectRunner(machine.registrationToken);
+    void tokens;
+    await new Promise((r) => setTimeout(r, 50));
+
+    runnerWs.send(
+      JSON.stringify({
+        type: "dropped_tool_block",
+        sessionId: "s1",
+        blockType: "tool_use",
+        reason: "missing_id",
+      }),
+    );
+    runnerWs.send(
+      JSON.stringify({
+        type: "dropped_tool_block",
+        sessionId: "s1",
+        blockType: "tool_result",
+        reason: "missing_tool_use_id",
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    const snap = hub.metrics.snapshot();
+    assert.equal(
+      snap["hub.dropped_tool_block{block_type=tool_use,reason=missing_id}"],
+      1,
+    );
+    assert.equal(
+      snap[
+        "hub.dropped_tool_block{block_type=tool_result,reason=missing_tool_use_id}"
+      ],
+      1,
+    );
+
+    await closeWs(runnerWs);
+  });
+});
+
 // ── Rate limiting ───────────────────────────────────────────────────────
 
 describe("rate limiting", () => {

--- a/hub/src/hub.ts
+++ b/hub/src/hub.ts
@@ -14,6 +14,7 @@ import type {
   HubToClientMsg,
   RespondToPromptMsg,
 } from "@cc-commander/protocol";
+import { HUB_METRIC, Metrics } from "@cc-commander/protocol/metrics";
 import type { HubDb } from "./db.ts";
 import type { AuthService, JwtPayload } from "./auth.ts";
 import { DuplicateEmailError } from "./auth.ts";
@@ -62,6 +63,12 @@ export interface HubConfig {
     refresh?: { capacity: number; perMinute: number };
     machineCreate?: { capacity: number; perHour: number };
   };
+  /**
+   * Inject a Metrics instance (mostly for tests, which want a fast
+   * flush interval and a captured emit). Production callers leave this
+   * unset and get the default 60s flush to console.log.
+   */
+  metrics?: Metrics;
 }
 
 export class Hub {
@@ -83,6 +90,7 @@ export class Hub {
   registerLimiter: TokenBucketRateLimiter;
   refreshLimiter: TokenBucketRateLimiter;
   machineCreateLimiter: TokenBucketRateLimiter;
+  metrics: Metrics;
 
   constructor(config: HubConfig) {
     this.config = config;
@@ -124,6 +132,7 @@ export class Hub {
       capacity: machine.capacity,
       refillPerMs: machine.perHour / 3_600_000,
     });
+    this.metrics = config.metrics ?? new Metrics();
 
     this.httpServer = createServer((req, res) => this.handleHttp(req, res));
     this.wss = new WebSocketServer({ server: this.httpServer });
@@ -135,6 +144,7 @@ export class Hub {
     this.registerLimiter.startSweeping();
     this.refreshLimiter.startSweeping();
     this.machineCreateLimiter.startSweeping();
+    this.metrics.start();
     return new Promise((resolve) => {
       this.httpServer.listen(this.config.port, () => resolve());
     });
@@ -146,6 +156,7 @@ export class Hub {
       this.registerLimiter.stop();
       this.refreshLimiter.stop();
       this.machineCreateLimiter.stop();
+      this.metrics.stop();
       for (const [, conn] of this.clients) conn.ws.close();
       for (const [, conn] of this.runners) conn.ws.close();
       for (const [, entry] of this.pendingHistoryRequests) {
@@ -394,6 +405,7 @@ export class Hub {
         const msg = parseClientMessage(data.toString());
         this.handleClientMessage(conn, msg);
       } catch (err) {
+        this.metrics.inc(HUB_METRIC.PARSE_REJECT, { source: "client" });
         this.sendToClient(conn, {
           type: "error",
           message: err instanceof Error ? err.message : "Unknown error",
@@ -527,6 +539,7 @@ export class Hub {
       const pending = this.pendingHistoryRequests.get(requestId);
       if (!pending) return;
       this.pendingHistoryRequests.delete(requestId);
+      this.metrics.inc(HUB_METRIC.HISTORY_TTL_EXPIRED);
       console.warn(
         `[hub] session_history TTL expired for request ${requestId} on machine ${pending.machineId}`,
       );
@@ -606,6 +619,7 @@ export class Hub {
         const msg = parseRunnerMessage(data.toString());
         this.handleRunnerMessage(conn, msg);
       } catch (err) {
+        this.metrics.inc(HUB_METRIC.PARSE_REJECT, { source: "runner" });
         console.error("Invalid runner message:", err);
       }
     });
@@ -649,6 +663,7 @@ export class Hub {
           // Either expired (TTL fired) or fabricated by a misbehaving
           // runner. Either way: do not broadcast unsolicited history to
           // every client on the account.
+          this.metrics.inc(HUB_METRIC.HISTORY_ORPHAN_REPLY);
           console.warn(
             `[hub] dropping session_history with unknown requestId from machine ${conn.machineId}`,
           );
@@ -656,12 +671,19 @@ export class Hub {
         }
         if (pending.machineId !== conn.machineId) {
           // The runner that replied isn't the one we asked. Drop.
+          this.metrics.inc(HUB_METRIC.HISTORY_ORPHAN_REPLY);
           console.warn(
             `[hub] session_history reply machineId mismatch (expected ${pending.machineId}, got ${conn.machineId})`,
           );
           break;
         }
         this.deletePendingHistory(msg.requestId);
+        if (msg.error) {
+          // Operators want degraded-fetch rate as much as orphan rate.
+          // The error code is from A1's closed set, so cardinality is
+          // bounded by the union (timeout|no_session|fetch_failed).
+          this.metrics.inc(HUB_METRIC.HISTORY_DEGRADED, { code: msg.error });
+        }
         this.sendToClient(pending.conn, msg);
         break;
       }
@@ -692,8 +714,12 @@ export class Hub {
 
       case "dropped_tool_block":
         // Pure observability signal: SDK shape drift surfaced by the
-        // runner-side guards. Logged here so a single grep on the hub
-        // catches it across the fleet; #44 follow-up wires a counter.
+        // runner-side guards. The labels are closed-set thanks to A1's
+        // parser validation, so cardinality is bounded.
+        this.metrics.inc(HUB_METRIC.DROPPED_TOOL_BLOCK, {
+          block_type: msg.blockType,
+          reason: msg.reason,
+        });
         console.warn(
           `[hub] dropped_tool_block machine=${conn.machineId} session=${msg.sessionId} block=${msg.blockType} reason=${msg.reason}`,
         );

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./metrics": "./src/metrics.ts"
   },
   "scripts": {
     "test": "node --test --experimental-strip-types 'src/__tests__/*.test.ts'",

--- a/protocol/src/__tests__/metrics.test.ts
+++ b/protocol/src/__tests__/metrics.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Metrics } from "../metrics.ts";
+
+describe("Metrics", () => {
+  // Counters are flat string→number; the snapshot must reflect every
+  // increment regardless of label insertion order.
+  it("increments and snapshots labeled counters", () => {
+    const m = new Metrics();
+    m.inc("dropped");
+    m.inc("dropped");
+    m.inc("dropped_with_labels", { reason: "missing_id", block: "tool_use" });
+    m.inc("dropped_with_labels", { block: "tool_use", reason: "missing_id" });
+    const snap = m.snapshot();
+    assert.equal(snap["dropped"], 2);
+    assert.equal(
+      snap["dropped_with_labels{block=tool_use,reason=missing_id}"],
+      2,
+    );
+  });
+
+  // Stable key encoding so the same (name, labels) always lands in the
+  // same map slot regardless of insertion order. Without this, label
+  // reordering would silently double-count.
+  it("encodes labels in sorted order", () => {
+    const m = new Metrics();
+    m.inc("c", { b: "2", a: "1" });
+    m.inc("c", { a: "1", b: "2" });
+    const snap = m.snapshot();
+    assert.equal(Object.keys(snap).length, 1);
+    assert.equal(snap["c{a=1,b=2}"], 2);
+  });
+
+  // Snapshots are cumulative: the operator computes deltas externally,
+  // so reset-on-flush would silently lose data between scrapes.
+  it("flush emits a single JSON line and does not reset counters", () => {
+    const lines: string[] = [];
+    const m = new Metrics({
+      flushIntervalMs: 1_000_000,
+      emit: (line) => lines.push(line),
+      now: () => 1_700_000_000_000,
+    });
+    m.inc("foo");
+    m.inc("bar");
+    m.flush();
+    assert.equal(lines.length, 1);
+    const parsed = JSON.parse(lines[0]) as {
+      kind: string;
+      ts: string;
+      counters: Record<string, number>;
+    };
+    assert.equal(parsed.kind, "metrics");
+    assert.equal(parsed.ts, "2023-11-14T22:13:20.000Z");
+    assert.equal(parsed.counters.foo, 1);
+    assert.equal(parsed.counters.bar, 1);
+    // Cumulative: counters survive the flush.
+    assert.deepEqual(m.snapshot(), { foo: 1, bar: 1 });
+  });
+
+  // No counters → no log line. Otherwise idle hubs would emit empty
+  // metric lines forever.
+  it("flush is a no-op when no counters have been incremented", () => {
+    const lines: string[] = [];
+    const m = new Metrics({ emit: (line) => lines.push(line) });
+    m.flush();
+    assert.equal(lines.length, 0);
+  });
+
+  // start() schedules periodic flushes; stop() cancels them. The unref
+  // contract is checked indirectly by the lack of a hung process in CI.
+  it("start schedules periodic flushes; stop cancels them", async () => {
+    const lines: string[] = [];
+    const m = new Metrics({
+      flushIntervalMs: 5,
+      emit: (line) => lines.push(line),
+    });
+    m.inc("ticks");
+    m.start();
+    await new Promise((r) => setTimeout(r, 30));
+    m.stop();
+    const after = lines.length;
+    assert.ok(after >= 1, "expected at least one flush within 30ms");
+    await new Promise((r) => setTimeout(r, 20));
+    // No additional flushes after stop().
+    assert.equal(lines.length, after);
+  });
+
+  // Idempotency: start() called twice must not double-schedule. Asserted
+  // by reference identity on the internal timer rather than wall-clock
+  // counting (which is flaky on loaded CI).
+  it("start is idempotent", () => {
+    const m = new Metrics({ flushIntervalMs: 1_000_000 });
+    m.start();
+    // Reach into the private field via index access. Acceptable in
+    // tests; the alternative is exposing a getter solely for testing.
+    const first = (m as unknown as { flushTimer: unknown }).flushTimer;
+    m.start();
+    const second = (m as unknown as { flushTimer: unknown }).flushTimer;
+    assert.strictEqual(first, second, "second start must reuse the timer");
+    m.stop();
+  });
+});

--- a/protocol/src/metrics.ts
+++ b/protocol/src/metrics.ts
@@ -1,0 +1,115 @@
+/**
+ * In-memory counter store with periodic structured-JSON flush. Sufficient
+ * for a single hub instance -- aggregator (Loki, Vector, journalctl) reads
+ * the JSON lines off stdout. If/when the hub is horizontally scaled this
+ * moves to push-based exposition (Prometheus pushgateway, OpenTelemetry).
+ *
+ * Counters only by design (no histograms / gauges yet). Adding those
+ * would change the wire shape, so they're held back until there's a
+ * concrete need.
+ */
+
+/**
+ * INVARIANT: callers must only pass closed-set label values. The runtime
+ * type allows arbitrary strings to keep the API ergonomic, but operator
+ * dashboards rely on cardinality being bounded by code, not by traffic.
+ * The A1 parser enforces the closed sets for all hub-side increments.
+ */
+export type MetricLabels = Record<string, string>;
+
+/**
+ * Canonical counter names. Centralized so a typo at a call site is a
+ * compile error instead of a phantom counter that operators only
+ * notice when their dashboard is silent. Mirrors A1's enum-validation
+ * philosophy: closed sets at the boundary.
+ */
+export const HUB_METRIC = {
+  PARSE_REJECT: "hub.parse_reject",
+  HISTORY_TTL_EXPIRED: "hub.history_ttl_expired",
+  HISTORY_ORPHAN_REPLY: "hub.history_orphan_reply",
+  HISTORY_DEGRADED: "hub.history_degraded",
+  DROPPED_TOOL_BLOCK: "hub.dropped_tool_block",
+} as const;
+
+export const RUNNER_METRIC = {
+  PARSE_REJECT: "runner.parse_reject",
+  DROPPED_TOOL_BLOCK: "runner.dropped_tool_block",
+} as const;
+
+export interface MetricsConfig {
+  /** How often to emit a snapshot. Default 60s. */
+  flushIntervalMs?: number;
+  /** Injection seam for tests. Defaults to console.log. */
+  emit?: (line: string) => void;
+  /** Injection seam for tests. Defaults to Date.now. */
+  now?: () => number;
+}
+
+export class Metrics {
+  private counters: Map<string, number> = new Map();
+  private flushTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly flushIntervalMs: number;
+  private readonly emit: (line: string) => void;
+  private readonly now: () => number;
+
+  constructor(config: MetricsConfig = {}) {
+    this.flushIntervalMs = config.flushIntervalMs ?? 60_000;
+    this.emit = config.emit ?? ((line) => console.log(line));
+    this.now = config.now ?? Date.now;
+  }
+
+  /**
+   * Increment a counter by 1. Labels are encoded into the key so the
+   * snapshot remains a flat string→number map (matches journald /
+   * Loki / OTEL counter shape).
+   */
+  inc(name: string, labels?: MetricLabels): void {
+    const key = encodeKey(name, labels);
+    this.counters.set(key, (this.counters.get(key) ?? 0) + 1);
+  }
+
+  /** Cumulative snapshot. Counters are NEVER reset on snapshot/flush. */
+  snapshot(): Record<string, number> {
+    return Object.fromEntries(this.counters);
+  }
+
+  /** Start the periodic flush. Idempotent. */
+  start(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setInterval(() => this.flush(), this.flushIntervalMs);
+    // Don't keep the event loop alive just to flush metrics.
+    this.flushTimer.unref?.();
+  }
+
+  stop(): void {
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+
+  /** Emit a single JSON snapshot line. Public so callers can flush on demand. */
+  flush(): void {
+    if (this.counters.size === 0) return;
+    this.emit(
+      JSON.stringify({
+        ts: new Date(this.now()).toISOString(),
+        kind: "metrics",
+        counters: this.snapshot(),
+      }),
+    );
+  }
+}
+
+/**
+ * Stable encoding so the same (name, labels) pair always lands in the
+ * same map slot regardless of label insertion order.
+ */
+function encodeKey(name: string, labels?: MetricLabels): string {
+  if (!labels) return name;
+  const parts = Object.keys(labels)
+    .sort()
+    .map((k) => `${k}=${labels[k]}`)
+    .join(",");
+  return parts.length === 0 ? name : `${name}{${parts}}`;
+}

--- a/runner/src/__tests__/runner.test.ts
+++ b/runner/src/__tests__/runner.test.ts
@@ -487,6 +487,49 @@ describe("protocol validation", () => {
 
     // Runner survived the malformed message
     assert.equal(runner.ws?.readyState, WebSocket.OPEN);
+    // #44 A3: parse rejections must be counted locally so an offline
+    // runner still has accounting when the hub-side counter is unreachable.
+    assert.equal(runner.metrics.snapshot()["runner.parse_reject"], 1);
+    runner.disconnect();
+  });
+
+  // #44 A3: dropped tool blocks must be counted on the runner side as
+  // well as the hub side. The local counter is the source of truth when
+  // the hub link is down or the hub-side counter resets on restart.
+  it("counts runner.dropped_tool_block when guard fires", async () => {
+    const runner = new MachineRunner({
+      hubUrl: `ws://localhost:${hubPort}`,
+      registrationToken: "test-token",
+      machineName: "Test",
+      queryFn: mockQuery([
+        {
+          type: "assistant",
+          message: {
+            content: [
+              { type: "tool_use", name: "Bash", input: { command: "ls" } },
+            ],
+          },
+        },
+        { type: "result", session_id: "sdk-m", num_turns: 1, duration_ms: 5 },
+      ]),
+    });
+    await runner.connect();
+    await waitForRunnerMsg((m) => m.type === "runner_hello");
+
+    sendToRunner({
+      type: "hub_start_session",
+      sessionId: "s-m",
+      directory: "/tmp",
+      prompt: "go",
+    });
+    await new Promise((r) => setTimeout(r, 200));
+
+    assert.equal(
+      runner.metrics.snapshot()[
+        "runner.dropped_tool_block{block_type=tool_use,reason=missing_id}"
+      ],
+      1,
+    );
     runner.disconnect();
   });
 });

--- a/runner/src/runner.ts
+++ b/runner/src/runner.ts
@@ -1,6 +1,7 @@
 import { WebSocket } from "ws";
 import { query, getSessionMessages } from "@anthropic-ai/claude-agent-sdk";
 import { parseHubMessage, serialize } from "@cc-commander/protocol";
+import { Metrics, RUNNER_METRIC } from "@cc-commander/protocol/metrics";
 import type {
   DroppedToolBlockMsg,
   HubToRunnerMsg,
@@ -49,6 +50,8 @@ export interface RunnerConfig {
   reconnectIntervalMs?: number;
   queryFn?: QueryFn;
   getSessionMessagesFn?: GetSessionMessagesFn;
+  /** Inject a Metrics instance (mostly for tests). */
+  metrics?: Metrics;
 }
 
 export class MachineRunner {
@@ -60,6 +63,7 @@ export class MachineRunner {
   reconnectTimer: ReturnType<typeof setTimeout> | null;
   queryFn: QueryFn;
   getSessionMessagesFn: GetSessionMessagesFn;
+  metrics: Metrics;
 
   constructor(config: RunnerConfig) {
     this.config = config;
@@ -71,9 +75,14 @@ export class MachineRunner {
     this.queryFn = config.queryFn || query;
     this.getSessionMessagesFn =
       config.getSessionMessagesFn || getSessionMessages;
+    this.metrics = config.metrics ?? new Metrics();
   }
 
   connect(): Promise<void> {
+    // Idempotent: reconnect re-enters connect() and start() is a no-op
+    // when the timer is already running, so counters keep flowing across
+    // reconnect storms without losing the running totals.
+    this.metrics.start();
     return new Promise((resolve, reject) => {
       const url = `${this.config.hubUrl}/ws/runner?token=${this.config.registrationToken}`;
       this.ws = new WebSocket(url);
@@ -96,6 +105,7 @@ export class MachineRunner {
           const msg = parseHubMessage(data.toString());
           this.handleMessage(msg);
         } catch (err) {
+          this.metrics.inc(RUNNER_METRIC.PARSE_REJECT);
           console.error("[runner] Invalid message from hub:", err);
         }
       });
@@ -120,6 +130,7 @@ export class MachineRunner {
 
   disconnect(): void {
     this.shouldReconnect = false;
+    this.metrics.stop();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -467,7 +478,13 @@ export class MachineRunner {
   ): void {
     // Surface SDK shape drift at the source instead of as a silent
     // hub-side rejection downstream. The dropped_tool_block message
-    // is the structured signal; the log line is the human view.
+    // is the structured signal; the log line is the human view; the
+    // metric is the operator view (counted on both runner and hub so
+    // an offline runner still has local accounting).
+    this.metrics.inc(RUNNER_METRIC.DROPPED_TOOL_BLOCK, {
+      block_type: payload.blockType,
+      reason: payload.reason,
+    });
     console.error(
       `[runner] dropped ${payload.blockType} (${payload.reason}): ${JSON.stringify(raw).slice(0, 200)}`,
     );


### PR DESCRIPTION
## Summary

Final workstream of #44 observability. Hub and runner keep in-memory cumulative counters and emit structured-JSON snapshots to stdout every 60s. Aggregators (Loki, Vector, journalctl, docker logs) scrape without needing an HTTP endpoint or auth surface.

**New shared module: \`@cc-commander/protocol/metrics\`**
- \`Metrics\` class: counters, periodic flush, injectable seams for tests
- \`HUB_METRIC\` / \`RUNNER_METRIC\` constant maps — typos become compile errors

**Hub counters (5 sites):**
- \`hub.parse_reject{source=client|runner}\` — parser failures
- \`hub.history_ttl_expired\` — TTL fires
- \`hub.history_orphan_reply\` — unknown requestId or machine mismatch
- \`hub.history_degraded{code=timeout|no_session|fetch_failed}\` — A1 error reply
- \`hub.dropped_tool_block{block_type, reason}\` — A1 SDK-drift signal

**Runner counters (2 sites):**
- \`runner.parse_reject\` — parseHubMessage failures
- \`runner.dropped_tool_block{block_type, reason}\` — local accounting for offline scenarios

All labels are closed-set (validated by A1's enum-aware parsers), so cardinality is bounded by code.

Skipped by design: HTTP \`/metrics\` endpoint (auth complexity); operators scrape stdout. Histograms/gauges are TBD.

## Test plan

- [x] \`npm test -w @cc-commander/protocol\` — 34 tests pass (+6 metrics)
- [x] \`npm test -w cc-commander-hub\` — 74 tests pass (+6 inc-site integration)
- [x] \`npm test -w cc-commander-runner\` — 21 tests pass (+1 dropped_tool_block + parse_reject assertion)
- [x] Full \`npm run typecheck\` clean across protocol/hub/runner
- [x] Idempotency test uses reference identity (not wall-clock) to avoid CI flake

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)