### PR TITLE
hub: complete the rate-limit story (#45)

### DIFF
--- a/hub/src/__tests__/hub.test.ts
+++ b/hub/src/__tests__/hub.test.ts
@@ -1042,6 +1042,187 @@ describe("rate limiting", () => {
     assert.equal(r2.status, 201);
     assert.equal(r3.status, 429);
   });
+
+  // #45: a determined attacker who creates N accounts (within the
+  // strict register limit) gets N × machineCreate quota unless we add
+  // a per-IP layer alongside the per-account one.
+  it("returns 429 when machine creation exceeds per-IP quota across accounts", async () => {
+    await hub.stop();
+    db.close();
+    db = new HubDb(":memory:");
+    auth = new AuthService(db, JWT_SECRET);
+    hub = new Hub({
+      port: 0,
+      db,
+      auth,
+      rateLimits: {
+        login: { capacity: 100, perMinute: 100 },
+        register: { capacity: 100, perMinute: 100 },
+        // Generous per-account so it can't be the limiter we hit.
+        machineCreate: { capacity: 100, perHour: 100 },
+        // Tight per-IP so the test exercises the new layer.
+        machineCreateIp: { capacity: 2, perHour: 0.0001 },
+      },
+    });
+    await hub.start();
+    const addr = hub.httpServer.address();
+    port = typeof addr === "object" && addr ? addr.port : 0;
+    baseUrl = `http://localhost:${port}`;
+
+    // Two accounts from "the same IP" (localhost in tests).
+    const a = await auth.register("a@test.com", "pw");
+    const b = await auth.register("b@test.com", "pw");
+    const r1 = await postJson("/api/machines", { name: "m1" }, a.token);
+    const r2 = await postJson("/api/machines", { name: "m2" }, b.token);
+    // Third request from EITHER account must hit the IP layer.
+    const r3 = await postJson("/api/machines", { name: "m3" }, a.token);
+    assert.equal(r1.status, 201);
+    assert.equal(r2.status, 201);
+    assert.equal(r3.status, 429);
+    assert.equal(
+      hub.metrics.snapshot()["hub.rate_limited{limiter=machine_ip}"],
+      1,
+    );
+  });
+
+  // #45: WS upgrade endpoints have no auth-side rate limit. Even
+  // rejected upgrades have non-zero cost (socket alloc, handshake, FD).
+  // Per-IP cap rejects with 429 BEFORE the upgrade completes.
+  it("returns 429 on excess /ws/client upgrades from one IP", async () => {
+    await hub.stop();
+    db.close();
+    db = new HubDb(":memory:");
+    auth = new AuthService(db, JWT_SECRET);
+    hub = new Hub({
+      port: 0,
+      db,
+      auth,
+      rateLimits: {
+        ...TEST_RATE_LIMITS,
+        wsUpgrade: { capacity: 2, perMinute: 0.0001 },
+      },
+    });
+    await hub.start();
+    const addr = hub.httpServer.address();
+    port = typeof addr === "object" && addr ? addr.port : 0;
+    baseUrl = `http://localhost:${port}`;
+
+    const tokens = await auth.register("u@test.com", "pw");
+    const ws1 = await connectClient(tokens.token);
+    const ws2 = await connectClient(tokens.token);
+    // Third upgrade attempt must hit the limiter and be rejected at
+    // the HTTP layer with a 429.
+    let rejected = false;
+    let statusCode = 0;
+    await new Promise<void>((resolve) => {
+      const ws = new WebSocket(
+        `ws://localhost:${port}/ws/client?token=${tokens.token}`,
+      );
+      ws.on("unexpected-response", (_req, res) => {
+        rejected = true;
+        statusCode = res.statusCode ?? 0;
+        resolve();
+      });
+      ws.on("open", () => resolve());
+      ws.on("error", () => resolve());
+    });
+    assert.equal(rejected, true, "third upgrade should have been rejected");
+    assert.equal(statusCode, 429);
+    // Metric must reflect the rejection so operators can tell a 429
+    // spike from a flat connection-count graph.
+    assert.equal(
+      hub.metrics.snapshot()["hub.rate_limited{limiter=ws_upgrade}"],
+      1,
+    );
+
+    await closeWs(ws1);
+    await closeWs(ws2);
+  });
+
+  // The verifyClient hook covers /ws/client and /ws/runner alike — lock
+  // the runner branch so a future split between client/runner upgrades
+  // doesn't silently lose the limit on one side.
+  it("returns 429 on excess /ws/runner upgrades from one IP", async () => {
+    await hub.stop();
+    db.close();
+    db = new HubDb(":memory:");
+    auth = new AuthService(db, JWT_SECRET);
+    hub = new Hub({
+      port: 0,
+      db,
+      auth,
+      rateLimits: {
+        ...TEST_RATE_LIMITS,
+        wsUpgrade: { capacity: 1, perMinute: 0.0001 },
+      },
+    });
+    await hub.start();
+    const addr = hub.httpServer.address();
+    port = typeof addr === "object" && addr ? addr.port : 0;
+    baseUrl = `http://localhost:${port}`;
+
+    const tokens = await auth.register("u@test.com", "pw");
+    const account = db.getAccountByEmail("u@test.com")!;
+    const machine = db.createMachine(account.id, "m");
+    void tokens;
+
+    const ws1 = await connectRunner(machine.registrationToken);
+    let rejected = false;
+    let statusCode = 0;
+    await new Promise<void>((resolve) => {
+      const ws = new WebSocket(
+        `ws://localhost:${port}/ws/runner?token=${machine.registrationToken}`,
+      );
+      ws.on("unexpected-response", (_req, res) => {
+        rejected = true;
+        statusCode = res.statusCode ?? 0;
+        resolve();
+      });
+      ws.on("open", () => resolve());
+      ws.on("error", () => resolve());
+    });
+    assert.equal(rejected, true);
+    assert.equal(statusCode, 429);
+
+    await closeWs(ws1);
+  });
+
+  // Independent-consumption invariant: when the IP layer has tokens
+  // but the per-account layer is empty, the per-account layer must
+  // still reject. This is asserted positively (not just by absence)
+  // so a future short-circuit can't silently re-introduce a bypass.
+  it("per-account rejection still fires when IP layer has tokens", async () => {
+    await hub.stop();
+    db.close();
+    db = new HubDb(":memory:");
+    auth = new AuthService(db, JWT_SECRET);
+    hub = new Hub({
+      port: 0,
+      db,
+      auth,
+      rateLimits: {
+        login: { capacity: 100, perMinute: 100 },
+        register: { capacity: 100, perMinute: 100 },
+        // Tight per-account, generous per-IP.
+        machineCreate: { capacity: 1, perHour: 0.0001 },
+        machineCreateIp: { capacity: 100, perHour: 100 },
+      },
+    });
+    await hub.start();
+    const addr = hub.httpServer.address();
+    port = typeof addr === "object" && addr ? addr.port : 0;
+    baseUrl = `http://localhost:${port}`;
+
+    const tokens = await auth.register("u@test.com", "pw");
+    const r1 = await postJson("/api/machines", { name: "m1" }, tokens.token);
+    const r2 = await postJson("/api/machines", { name: "m2" }, tokens.token);
+    assert.equal(r1.status, 201);
+    assert.equal(r2.status, 429);
+    assert.equal(
+      hub.metrics.snapshot()["hub.rate_limited{limiter=machine_account}"],
+      1,
+    );
+  });
 });
 
 // ── Input validation ────────────────────────────────────────────────────

--- a/hub/src/hub.ts
+++ b/hub/src/hub.ts
@@ -62,6 +62,14 @@ export interface HubConfig {
     register?: { capacity: number; perMinute: number };
     refresh?: { capacity: number; perMinute: number };
     machineCreate?: { capacity: number; perHour: number };
+    /** Per-IP cap on /api/machines POSTs, layered ON TOP of the per-account
+     *  machineCreate limiter so multi-account abuse from one source IP
+     *  is bounded. Default 20/hour/IP. */
+    machineCreateIp?: { capacity: number; perHour: number };
+    /** Per-IP cap on /ws/{client,runner} upgrade attempts. Even rejected
+     *  upgrades have non-zero cost (socket alloc, handshake). Default
+     *  30/min/IP. */
+    wsUpgrade?: { capacity: number; perMinute: number };
   };
   /**
    * Inject a Metrics instance (mostly for tests, which want a fast
@@ -90,6 +98,14 @@ export class Hub {
   registerLimiter: TokenBucketRateLimiter;
   refreshLimiter: TokenBucketRateLimiter;
   machineCreateLimiter: TokenBucketRateLimiter;
+  machineCreateIpLimiter: TokenBucketRateLimiter;
+  wsUpgradeLimiter: TokenBucketRateLimiter;
+  /**
+   * All limiter instances in one place so start/stop sweeping is a
+   * single loop. Adding a new limiter only requires registering it
+   * here and at the call site, not in three lifecycle methods.
+   */
+  private limiters: TokenBucketRateLimiter[];
   metrics: Metrics;
 
   constructor(config: HubConfig) {
@@ -116,6 +132,19 @@ export class Hub {
       capacity: 10,
       perHour: 10,
     };
+    // 60/hour/IP (not 20) so legitimate users behind shared NAT
+    // (corporate, mobile carrier CGNAT, university) aren't immediately
+    // false-positived. The per-account layer (10/hour) still bounds
+    // single-user abuse; this layer exists to bound multi-account
+    // abuse from one source IP.
+    const machineIp = config.rateLimits?.machineCreateIp ?? {
+      capacity: 60,
+      perHour: 60,
+    };
+    const wsUpgrade = config.rateLimits?.wsUpgrade ?? {
+      capacity: 30,
+      perMinute: 30,
+    };
     this.loginLimiter = new TokenBucketRateLimiter({
       capacity: login.capacity,
       refillPerMs: login.perMinute / 60_000,
@@ -132,18 +161,47 @@ export class Hub {
       capacity: machine.capacity,
       refillPerMs: machine.perHour / 3_600_000,
     });
+    this.machineCreateIpLimiter = new TokenBucketRateLimiter({
+      capacity: machineIp.capacity,
+      refillPerMs: machineIp.perHour / 3_600_000,
+    });
+    this.wsUpgradeLimiter = new TokenBucketRateLimiter({
+      capacity: wsUpgrade.capacity,
+      refillPerMs: wsUpgrade.perMinute / 60_000,
+    });
+    this.limiters = [
+      this.loginLimiter,
+      this.registerLimiter,
+      this.refreshLimiter,
+      this.machineCreateLimiter,
+      this.machineCreateIpLimiter,
+      this.wsUpgradeLimiter,
+    ];
     this.metrics = config.metrics ?? new Metrics();
 
     this.httpServer = createServer((req, res) => this.handleHttp(req, res));
-    this.wss = new WebSocketServer({ server: this.httpServer });
+    this.wss = new WebSocketServer({
+      server: this.httpServer,
+      // Per-IP rate limit BEFORE the upgrade completes. Even rejected
+      // upgrades have non-zero cost (socket alloc, handshake, FD), and
+      // an attacker can hold half-open sockets to the FD ceiling. The
+      // ws library's two-arg verifyClient lets us set the HTTP status
+      // so the client (or attacker's botnet) sees a real 429 instead
+      // of the default 401.
+      verifyClient: (info, cb) => {
+        if (!this.wsUpgradeLimiter.tryConsume(clientIp(info.req))) {
+          this.metrics.inc(HUB_METRIC.RATE_LIMITED, { limiter: "ws_upgrade" });
+          cb(false, 429, "Too Many Requests");
+          return;
+        }
+        cb(true);
+      },
+    });
     this.wss.on("connection", (ws, req) => this.handleConnection(ws, req));
   }
 
   start(): Promise<void> {
-    this.loginLimiter.startSweeping();
-    this.registerLimiter.startSweeping();
-    this.refreshLimiter.startSweeping();
-    this.machineCreateLimiter.startSweeping();
+    for (const limiter of this.limiters) limiter.startSweeping();
     this.metrics.start();
     return new Promise((resolve) => {
       this.httpServer.listen(this.config.port, () => resolve());
@@ -152,10 +210,7 @@ export class Hub {
 
   stop(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.loginLimiter.stop();
-      this.registerLimiter.stop();
-      this.refreshLimiter.stop();
-      this.machineCreateLimiter.stop();
+      for (const limiter of this.limiters) limiter.stop();
       this.metrics.stop();
       for (const [, conn] of this.clients) conn.ws.close();
       for (const [, conn] of this.runners) conn.ws.close();
@@ -215,6 +270,7 @@ export class Hub {
     const limiter =
       action === "register" ? this.registerLimiter : this.loginLimiter;
     if (!limiter.tryConsume(ip)) {
+      this.metrics.inc(HUB_METRIC.RATE_LIMITED, { limiter: action });
       res.writeHead(429);
       res.end(JSON.stringify({ error: "Too many requests" }));
       return;
@@ -246,6 +302,7 @@ export class Hub {
     res: ServerResponse,
   ): Promise<void> {
     if (!this.refreshLimiter.tryConsume(clientIp(req))) {
+      this.metrics.inc(HUB_METRIC.RATE_LIMITED, { limiter: "refresh" });
       res.writeHead(429);
       res.end(JSON.stringify({ error: "Too many requests" }));
       return;
@@ -281,7 +338,21 @@ export class Hub {
       return;
     }
 
-    if (!this.machineCreateLimiter.tryConsume(payload.accountId)) {
+    // Two-layer check: per-account (existing) catches rapid abuse from
+    // a single user; per-IP (new) catches multi-account abuse from one
+    // source. Both layers consume independently so the tokens reflect
+    // attempts, not survivors -- a wasted token regenerates at the
+    // configured rate either way.
+    const accountOk = this.machineCreateLimiter.tryConsume(payload.accountId);
+    const ipOk = this.machineCreateIpLimiter.tryConsume(clientIp(req));
+    if (!accountOk || !ipOk) {
+      // Label which layer rejected so operators can tell single-user
+      // abuse from multi-account abuse from one IP. If both layers
+      // rejected on the same call, "machine_account" wins (per-account
+      // is the user-visible quota and the more specific signal).
+      this.metrics.inc(HUB_METRIC.RATE_LIMITED, {
+        limiter: !accountOk ? "machine_account" : "machine_ip",
+      });
       res.writeHead(429);
       res.end(JSON.stringify({ error: "Too many machines created recently" }));
       return;
@@ -780,7 +851,14 @@ const BEARER_PREFIX = "Bearer ";
  * unconditionally would let any caller spoof their bucket key.
  */
 function clientIp(req: IncomingMessage): string {
-  return req.socket.remoteAddress ?? "unknown";
+  const raw = req.socket.remoteAddress ?? "unknown";
+  // Normalize IPv4-mapped IPv6 (::ffff:1.2.3.4 → 1.2.3.4) so the same
+  // attacker connecting over both stacks lands in the same bucket. Same
+  // for IPv6 loopback (::1) which we map to 127.0.0.1 to match localhost
+  // tests and reverse proxies that forward over IPv4.
+  if (raw.startsWith("::ffff:")) return raw.slice("::ffff:".length);
+  if (raw === "::1") return "127.0.0.1";
+  return raw;
 }
 
 function extractBearerToken(req: IncomingMessage): string | null {

--- a/protocol/src/metrics.ts
+++ b/protocol/src/metrics.ts
@@ -29,6 +29,7 @@ export const HUB_METRIC = {
   HISTORY_ORPHAN_REPLY: "hub.history_orphan_reply",
   HISTORY_DEGRADED: "hub.history_degraded",
   DROPPED_TOOL_BLOCK: "hub.dropped_tool_block",
+  RATE_LIMITED: "hub.rate_limited",
 } as const;
 
 export const RUNNER_METRIC = {


### PR DESCRIPTION
## Summary

Closes #45. Two new limiters + metric integration + clientIp hardening.

**New limiters:**
- \`wsUpgradeLimiter\` (30/min/IP): rejects /ws/{client,runner} upgrades via the WebSocketServer \`verifyClient\` hook BEFORE the HTTP upgrade completes. Even socket-allocation cost is bounded.
- \`machineCreateIpLimiter\` (60/hour/IP): layered ON TOP of existing per-account limiter so multi-account abuse from one source is bounded. Both layers consume independently — no short-circuit OR.

**Hardening (from PR review):**
- \`clientIp()\` normalizes IPv4-mapped IPv6 (\`::ffff:1.2.3.4\` → \`1.2.3.4\`) and \`::1\` → \`127.0.0.1\`. Affects all 5 limiters, closes a bypass where the same attacker hitting both stacks landed in two buckets.
- All 6 rate-limit rejection sites now emit \`hub.rate_limited{limiter=...}\` via the #44 metrics infra. Labels: \`login\`, \`register\`, \`refresh\`, \`machine_account\`, \`machine_ip\`, \`ws_upgrade\`.
- Six limiter fields collapsed to a \`this.limiters\` array so start/stop is one loop.

**Defaults rationale:** 60/hour/IP for machineCreate (not 20) so legitimate CGNAT/office users aren't false-positived. 10/hour/account still bounds single-user abuse.

## Test plan

- [x] \`npm test -w cc-commander-hub\` — 78 tests pass (+4 from baseline)
- [x] /ws/client AND /ws/runner rejection cases (separate tests)
- [x] Per-IP machine rejection across two accounts
- [x] Independent-consumption invariant positively asserted
- [x] Metric assertions on every new rejection path
- [x] \`npm run typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)