### PR TITLE
hub: index clients by account so relayToClients is O(account) (#22)

### DIFF
--- a/hub/src/__tests__/hub.test.ts
+++ b/hub/src/__tests__/hub.test.ts
@@ -580,6 +580,72 @@ describe("runner disconnect cleanup", () => {
   });
 });
 
+// ── Per-account relay index ─────────────────────────────────────────────
+
+describe("per-account relay index", () => {
+  // #22: relay must NOT iterate every connected client. Two accounts
+  // connected to the same hub: a stream_text from one account's
+  // session must reach only that account's clients, with the other
+  // account's client seeing nothing.
+  it("does not relay account A messages to account B clients", async () => {
+    const a = await auth.register("a@test.com", "pw");
+    const b = await auth.register("b@test.com", "pw");
+    const accountA = db.getAccountByEmail("a@test.com")!;
+    const machineA = db.createMachine(accountA.id, "ma");
+    const sessionA = db.createSession(accountA.id, machineA.id, "/tmp", "idle");
+
+    const runnerA = await connectRunner(machineA.registrationToken);
+    const clientA = await connectClient(a.token);
+    const clientB = await connectClient(b.token);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const bMessages: any[] = [];
+    clientB.on("message", (data) =>
+      bMessages.push(JSON.parse(data.toString())),
+    );
+
+    const aSawText = waitForMsg(
+      clientA,
+      (m) => m.type === "stream_text" && m.content === "hello",
+    );
+    runnerA.send(
+      JSON.stringify({
+        type: "stream_text",
+        sessionId: sessionA.id,
+        content: "hello",
+      }),
+    );
+    await aSawText;
+
+    // Give B a moment to (incorrectly) receive the relay.
+    await new Promise((r) => setTimeout(r, 50));
+    assert.equal(
+      bMessages.find((m) => m.type === "stream_text"),
+      undefined,
+      "account B must not see account A's stream_text",
+    );
+
+    await closeWs(clientA);
+    await closeWs(clientB);
+    await closeWs(runnerA);
+  });
+
+  // #22: secondary index must drop empty buckets so a one-shot account
+  // doesn't permanently grow the map. Verified via reflection on the
+  // private map size.
+  it("clientsByAccount drops empty buckets on disconnect", async () => {
+    const a = await auth.register("a@test.com", "pw");
+    const clientA = await connectClient(a.token);
+    await new Promise((r) => setTimeout(r, 50));
+    const idx = (hub as unknown as { clientsByAccount: Map<string, unknown> })
+      .clientsByAccount;
+    assert.equal(idx.size, 1);
+    await closeWs(clientA);
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(idx.size, 0);
+  });
+});
+
 // ── Pending history request cleanup ─────────────────────────────────────
 
 describe("pending history cleanup", () => {

--- a/hub/src/hub.ts
+++ b/hub/src/hub.ts
@@ -75,6 +75,13 @@ export interface HubConfig {
 export class Hub {
   config: HubConfig;
   clients: Map<string, ClientConnection>;
+  /**
+   * Secondary index of connections by account, kept in lockstep with
+   * `clients`. relayToClients walks ONLY the relevant account's set
+   * instead of every connected client, so a stream-text token from
+   * one user no longer pays for every other user on the hub.
+   */
+  private clientsByAccount: Map<string, Set<ClientConnection>>;
   runners: Map<string, RunnerConnection>;
   /** Per-request TTL store for in-flight get_session_history calls. */
   pendingHistory: PendingHistoryStore;
@@ -97,6 +104,7 @@ export class Hub {
   constructor(config: HubConfig) {
     this.config = config;
     this.clients = new Map();
+    this.clientsByAccount = new Map();
     this.runners = new Map();
     this.pendingHistory = new PendingHistoryStore(
       // Default lives on the store; pass through only if explicitly set.
@@ -203,6 +211,8 @@ export class Hub {
       this.metrics.stop();
       for (const [, conn] of this.clients) conn.ws.close();
       for (const [, conn] of this.runners) conn.ws.close();
+      this.clients.clear();
+      this.clientsByAccount.clear();
       this.pendingHistory.clear();
       this.wss.close(() => {
         this.httpServer.close((err) => (err ? reject(err) : resolve()));
@@ -308,7 +318,7 @@ export class Hub {
       accountId: payload.accountId,
       email: payload.email,
     };
-    this.clients.set(connectionId, conn);
+    this.addClient(connectionId, conn);
 
     this.handleListSessions(conn);
     this.handleListMachines(conn);
@@ -327,9 +337,29 @@ export class Hub {
     });
 
     ws.on("close", () => {
-      this.clients.delete(connectionId);
+      this.removeClient(connectionId, conn);
       this.pendingHistory.dropMatching((entry) => entry.conn === conn);
     });
+  }
+
+  private addClient(connectionId: string, conn: ClientConnection): void {
+    this.clients.set(connectionId, conn);
+    let bucket = this.clientsByAccount.get(conn.accountId);
+    if (!bucket) {
+      bucket = new Set();
+      this.clientsByAccount.set(conn.accountId, bucket);
+    }
+    bucket.add(conn);
+  }
+
+  private removeClient(connectionId: string, conn: ClientConnection): void {
+    this.clients.delete(connectionId);
+    const bucket = this.clientsByAccount.get(conn.accountId);
+    if (!bucket) return;
+    bucket.delete(conn);
+    // Drop the account bucket entirely once empty so the secondary
+    // index doesn't grow forever for one-shot accounts.
+    if (bucket.size === 0) this.clientsByAccount.delete(conn.accountId);
   }
 
   private handleClientMessage(
@@ -655,11 +685,9 @@ export class Hub {
   }
 
   private relayToClients(accountId: string, msg: HubToClientMsg): void {
-    for (const [, conn] of this.clients) {
-      if (conn.accountId === accountId) {
-        this.sendToClient(conn, msg);
-      }
-    }
+    const bucket = this.clientsByAccount.get(accountId);
+    if (!bucket) return;
+    for (const conn of bucket) this.sendToClient(conn, msg);
   }
 
   private broadcastSessionList(accountId: string): void {


### PR DESCRIPTION
## Summary

Closes #22. Adds a secondary index \`clientsByAccount: Map<accountId, Set<ClientConnection>>\` maintained in lockstep with the primary \`clients\` map. \`relayToClients\` walks ONLY the relevant bucket, so a stream_text token from one user no longer pays the cost of every other connected client.

- \`addClient\`/\`removeClient\` helpers keep the two maps consistent
- Empty buckets are dropped on the last disconnect so one-shot accounts don't grow the map forever
- \`Hub.stop()\` clears both maps alongside \`pendingHistory.clear()\`

## Test plan

- [x] \`npm test -w cc-commander-hub\` — 89 tests pass (+2 new)
- [x] Positive cross-account isolation test (account A stream_text MUST NOT reach account B client)
- [x] Reflection test on the secondary index size to lock the empty-bucket-drop invariant
- [x] All existing relay tests still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)