### PR TITLE
chore(swift): gitignore xcodebuild output dir

### DIFF
--- a/client/swift/.gitignore
+++ b/client/swift/.gitignore
@@ -2,3 +2,4 @@
 DerivedData/
 *.xcuserdata/
 xcuserdata/
+build/


### PR DESCRIPTION
## Summary
- Add `build/` to `client/swift/.gitignore` so xcodebuild artifacts don't dirty the working tree.

## Test plan
- [x] Run an Xcode build, confirm `git status` stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)