### PR TITLE
Scope debug machineIds per-account, bump JWT TTL, refresh DEPLOY.md

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -46,11 +46,15 @@ The compose file binds the container to `127.0.0.1:3000` so it is **not**
 publicly reachable until you put a reverse proxy in front of it. SQLite is
 persisted in the named volume `hub-data`.
 
-### Updating: pull + restart
+### Updating: auto-deploy on push to main
 
-The hub image is built and pushed to GHCR by `.github/workflows/release.yml`
-on every push to `main` and on every `v*` tag. To pull a new build on the
-VPS:
+`.github/workflows/release.yml` builds and pushes the hub image to GHCR
+on every push to `main`, then SSHes into the VPS and rolls the
+container forward. No manual step is required once the deploy secrets
+are configured (see "Auto-deploy secrets" below).
+
+If the auto-deploy job is disabled (no `DEPLOY_SSH_HOST` secret), or
+you want to deploy a one-off build by hand on the VPS:
 
 ```sh
 cd cc-commander/hub
@@ -58,24 +62,38 @@ git pull
 JWT_SECRET=... docker compose up -d --build
 ```
 
-If you'd rather pull the prebuilt image instead of rebuilding from source,
-edit `docker-compose.yml` to use `image: ghcr.io/eliasschlie/cc-commander-hub:main`
-and run `docker compose pull && docker compose up -d`.
+#### Auto-deploy secrets
+
+Set these in **Repo Settings → Secrets → Actions**:
+
+| Secret             | Notes                                                           |
+| ------------------ | --------------------------------------------------------------- |
+| `DEPLOY_SSH_HOST`  | VPS hostname. Presence of this secret enables the deploy job.   |
+| `DEPLOY_SSH_USER`  | SSH user (e.g. `ccuser`)                                        |
+| `DEPLOY_SSH_KEY`   | Private key. Pubkey lives in `~/.ssh/authorized_keys` on the VPS. |
+| `DEPLOY_SSH_PORT`  | Optional, defaults to 22                                        |
+| `DEPLOY_HUB_DIR`   | Optional, defaults to `~/cc-commander/hub`                      |
+
+The deploy job runs `git fetch && git reset --hard origin/main` on the
+VPS, then `docker compose up -d --build --force-recreate`, then polls
+`https://$DEPLOY_SSH_HOST/api/version` until it reports the SHA CI just
+built. If the verify step times out (~90s), the workflow fails loudly
+so a stale rollout doesn't go unnoticed.
 
 ### How runners stay in sync with the hub
 
-The hub bakes a `VERSION` (git short SHA on `main` builds, or the tag name
-on `v*` builds) into the image and serves it from `GET /api/version`.
-Each runner polls that endpoint every 5 minutes (configurable via
-`CC_COMMANDER_POLL_MS`). When the runner's own checked-out commit no
-longer matches the hub's `VERSION`, the runner runs `runner/scripts/update.sh`
-(`git fetch && git checkout origin/main && npm ci -w cc-commander-runner`), exits cleanly,
-and launchd restarts it against the new code. Logs land in
+The hub bakes a `VERSION` (full git SHA) into the image and serves it
+from `GET /api/version`. Each runner polls that endpoint every 5 minutes
+(configurable via `CC_COMMANDER_POLL_MS`). When the runner's own
+checked-out commit no longer matches the hub's `VERSION`, the runner
+runs `runner/scripts/update.sh` synchronously (`git fetch && git
+checkout origin/main && npm ci`), then exits and launchd restarts it
+against the new code. Logs land in
 `~/Library/Logs/cc-commander-runner-update.log`.
 
-So the deploy story is: **push to main → CI builds the hub image with
-the new SHA → you redeploy the hub → every runner picks up the new code
-within 5 minutes**. No per-runner intervention.
+So the deploy story is: **push to main → CI builds and SSH-deploys the
+hub → every runner picks up the new code within 5 minutes**. No
+per-runner intervention.
 
 If the hub's `VERSION` is empty (e.g. local dev hub), runners skip the
 self-update protocol entirely.

--- a/hub/src/__tests__/hub.test.ts
+++ b/hub/src/__tests__/hub.test.ts
@@ -1578,6 +1578,47 @@ describe("GET /api/debug/state", () => {
     assert.ok(Array.isArray(data.recentFailedSessions));
   });
 
+  // Prevents: cross-account enumeration of connected runner machineIds
+  // via /api/debug/state. The aggregate `runners.count` stays global;
+  // only the per-account `runners.machineIds` list is filtered.
+  it("only returns runners.machineIds for the requester's account", async () => {
+    const a = await auth.register("ra@test.com", "password");
+    const b = await auth.register("rb@test.com", "password");
+    const machineA = db.createMachine(
+      auth.verifyToken(a.token).accountId,
+      "ma",
+    );
+    const machineB = db.createMachine(
+      auth.verifyToken(b.token).accountId,
+      "mb",
+    );
+    const wsA = await connectRunner(machineA.registrationToken);
+    const wsB = await connectRunner(machineB.registrationToken);
+    try {
+      const fetchAs = async (token: string) => {
+        const res = await fetch(`${baseUrl}/api/debug/state`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        return (await res.json()) as {
+          runners: { count: number; machineIds: string[] };
+        };
+      };
+      const dataA = await fetchAs(a.token);
+      const dataB = await fetchAs(b.token);
+      // Aggregate count is global -- both runners are connected.
+      assert.equal(dataA.runners.count, 2);
+      assert.equal(dataB.runners.count, 2);
+      // Each caller sees only their own machineId. Asserting both
+      // sides catches a "always return requester X" style bug that a
+      // one-sided check would miss.
+      assert.deepEqual(dataA.runners.machineIds, [machineA.id]);
+      assert.deepEqual(dataB.runners.machineIds, [machineB.id]);
+    } finally {
+      wsA.close();
+      wsB.close();
+    }
+  });
+
   // Prevents: cross-account leak via /api/debug/state
   it("only returns recentFailedSessions for the requester's account", async () => {
     const a = await auth.register("a@test.com", "password");

--- a/hub/src/auth.ts
+++ b/hub/src/auth.ts
@@ -10,7 +10,9 @@ export class DuplicateEmailError extends Error {
 }
 
 const SALT_ROUNDS = 10;
-const JWT_EXPIRY = "15m";
+// Short-lived access token. Long sessions are handled by the 30-day
+// refresh token below, not by extending this.
+const JWT_EXPIRY = "1h";
 const REFRESH_EXPIRY_DAYS = 30;
 
 export interface TokenPair {

--- a/hub/src/hub.ts
+++ b/hub/src/hub.ts
@@ -264,7 +264,7 @@ export class Hub {
       // Debug endpoint reads live state directly off the Hub. Closure
       // (rather than passing the Hub class) keeps routes/ from
       // depending on hub.ts; see RouteContext jsdoc.
-      debugSnapshot: () => this.debugSnapshot(),
+      debugSnapshot: (accountId) => this.debugSnapshot(accountId),
     };
   }
 
@@ -273,8 +273,18 @@ export class Hub {
    * never returns auth tokens, registration tokens, account ids, or
    * any per-user content. Designed to be safe to surface to anyone who
    * already has a hub-issued JWT.
+   *
+   * `runners.machineIds` is filtered to the requesting account so one
+   * account can't enumerate every other account's connected machines.
+   * Aggregate counts (`runners.count`, `clients.count`,
+   * `clients.accounts`) stay global -- they're hub-wide health
+   * signals already exposed via metrics.
    */
-  debugSnapshot(): DebugSnapshot {
+  debugSnapshot(accountId: string): DebugSnapshot {
+    const ownMachineIds: string[] = [];
+    for (const conn of this.runners.values()) {
+      if (conn.accountId === accountId) ownMachineIds.push(conn.machineId);
+    }
     return {
       version: this.config.version ?? "",
       startedAt: this.startedAt,
@@ -283,7 +293,7 @@ export class Hub {
       port: this.config.port,
       runners: {
         count: this.runners.size,
-        machineIds: Array.from(this.runners.keys()),
+        machineIds: ownMachineIds,
       },
       clients: {
         count: this.clients.size,

--- a/hub/src/routes/debug.ts
+++ b/hub/src/routes/debug.ts
@@ -11,12 +11,10 @@
  *   - All counter snapshots from the Metrics module
  *
  * Auth: requires a valid hub-issued JWT in the Authorization header.
- * Same verification path as /ws/client. The endpoint is read-only and
- * deliberately leaks no per-account or per-session content -- it
- * surfaces *what already shows up in metrics*, never tokens or DB
- * rows. Anyone holding any account's JWT can call it; that's an
- * intentional trade-off so the hub doesn't need a separate admin role
- * just for introspection.
+ * Same verification path as /ws/client. Per-account fields
+ * (`runners.machineIds`, `recentFailedSessions`) are scoped to the
+ * requester's account so one account can't enumerate other accounts'
+ * machines or read their failure logs.
  */
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { JwtPayload } from "../auth.ts";
@@ -43,7 +41,7 @@ export function handleDebugState(
     return;
   }
 
-  const snapshot = ctx.debugSnapshot();
+  const snapshot = ctx.debugSnapshot(payload.accountId);
 
   // Per-account post-mortem slice. Limited to the requester's
   // account so /api/debug/state can return failed sessions without

--- a/hub/src/routes/types.ts
+++ b/hub/src/routes/types.ts
@@ -34,10 +34,10 @@ export interface RouteContext {
   /**
    * Returns a redacted snapshot of hub state for /api/debug/state.
    * Closure (not a Hub reference) so the routes/ layer doesn't pull
-   * in hub.ts; the literal carries only counts and ids that already
-   * appear in metrics or are derivable from public message flow.
+   * in hub.ts. `accountId` scopes per-account fields; see
+   * Hub.debugSnapshot() for the full contract.
    */
-  debugSnapshot(): DebugSnapshot;
+  debugSnapshot(accountId: string): DebugSnapshot;
 }
 
 /**


### PR DESCRIPTION
## Summary

Three small fixes from the post-deploy catalogued issue list:

- **Security**: `/api/debug/state`'s `runners.machineIds` was global. Any authenticated account could enumerate every other account's connected machines. Now filtered to the requester's account. Aggregate counts (`runners.count`, `clients.count`) stay global since they're already exposed via metrics.
- **DX**: Bump access-token TTL from 15m → 1h. The 30-day refresh-token rotation is the long-session mechanism; 15m forced E2E test scripts and long debugging sessions to re-login mid-flow. Stolen-token blast radius bumps from 15m to 1h, well inside the existing threat model.
- **Docs**: `DEPLOY.md` still said deploy was manual. Refresh to describe the auto-deploy pipeline that landed in #63 (SSH job + `/api/version` poll), and document the required `DEPLOY_SSH_*` secrets.

## Test plan

- [x] `npm run typecheck -w cc-commander-hub` passes
- [x] `npm test -w cc-commander-hub` -- 101/101 pass (added bidirectional cross-account assertion: A sees only A's machineId, B sees only B's, both see `runners.count=2`)
- [ ] CI green
- [ ] Auto-deploy lands the new SHA on the VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)