### PR TITLE
Build script + doc cleanups from retrospective review

### DIFF
--- a/client/swift/CLAUDE.md
+++ b/client/swift/CLAUDE.md
@@ -36,9 +36,13 @@ open "$(./scripts/build-app.sh)"
 
 `scripts/build-app.sh` is the *only* sanctioned local build path. It:
 - runs xcodebuild with no signing override flags
-- finds the freshly-built `.app` under DerivedData (handles per-worktree path hashes)
+- queries `xcodebuild -showBuildSettings BUILT_PRODUCTS_DIR` to find the
+  freshly-built `.app` directly (no DerivedData scanning)
 - verifies `codesign` reports `TeamIdentifier=Q2U8K9N3BL` and bails loud if not
 - prints the .app path on stdout for piping into `open`
+
+For forks: set `CCC_EXPECTED_TEAM=YOURTEAM` to override the expected
+team without editing the script. project.yml needs the same change.
 
 **Do NOT pass `DEVELOPMENT_TEAM=` or `CODE_SIGN_IDENTITY=-` to xcodebuild
 for local builds.** Both project.yml and the generated xcodeproj set the

--- a/client/swift/TESTING.md
+++ b/client/swift/TESTING.md
@@ -150,13 +150,17 @@ cd client/swift
 APP=$(./scripts/build-app.sh)
 echo "Using $APP"
 
-# 2. Launch with the harness env vars. Run the executable directly --
-#    `open` doesn't propagate env vars cleanly.
+# 2. Launch with the harness env vars. Run the Mach-O executable
+#    directly (NOT `open`) so the env vars propagate. The Keychain
+#    ACL is keyed on the .app's code-signature identity, not on the
+#    launch path -- verified empirically that direct exec keeps
+#    `hasStoredCredentials: true` without prompting, as long as the
+#    binary is signed (build-app.sh enforces this).
 LOG_FILE=/tmp/ccc-gui.log \
 CC_COMMANDER_CMD_FILE=/tmp/ccc-gui.cmd \
 "$APP/Contents/MacOS/CCCommander" &
 
-# 4. Drive it the same way as ccc-shadow.
+# 3. Drive it the same way as ccc-shadow.
 tail -F /tmp/ccc-gui.log | grep harness_ &
 cat <<'EOF' >> /tmp/ccc-gui.cmd
 {"id":"1","cmd":"snapshot"}
@@ -164,6 +168,23 @@ cat <<'EOF' >> /tmp/ccc-gui.cmd
 {"id":"3","cmd":"quit"}
 EOF
 ```
+
+### Collaborative debugging mode
+
+The harness and SwiftUI manipulate **the same `@MainActor AppState`**.
+When you launch with `CC_COMMANDER_CMD_FILE` set, the runner loop yields
+the main actor every 100 ms via `Task.sleep`, so the GUI window keeps
+rendering and accepting clicks **at the same time** the harness is
+ready to dispatch commands. Result: the user clicks around in the
+window AND the agent appends commands to `$CC_COMMANDER_CMD_FILE`, and
+both observe the same shared state in real time.
+
+This is the recommended way to drive a worktree-built instance during
+interactive debugging: a Claude Code session reads the log file to see
+what the user just clicked, and the user sees agent-issued commands
+take effect in the visible UI. The runner only exits on an explicit
+`quit` command, so the GUI remains alive across an arbitrary number
+of agent interactions.
 
 If the app prompts you for a keychain password on launch, **stop** —
 that means the binary's code signature changed since the JWT was
@@ -193,20 +214,25 @@ tail -F /tmp/ccc.log | grep harness_
 
 # Terminal C — script the whole loop. Note the `id` on every line:
 # response records carry the same id so you can match them deterministically.
+# IMPORTANT: the `MACHINE_ID` and `SESSION_ID` placeholders below are
+# NOT valid JSON. A real controller reads them out of the previous
+# response's `result` field and substitutes them at runtime; pasting
+# this block as-is will produce JSON parse errors from the runner.
 cat <<'EOF' >> /tmp/ccc.cmd
 {"id":"1","cmd":"login","args":{"email":"you@example.com","password":"secret"}}
 {"id":"2","cmd":"waitForBootstrap","args":{"timeout":10}}
 {"id":"3","cmd":"snapshot"}
-{"id":"4","cmd":"startSession","args":{"machineId":"<from snapshot>","directory":"/Users/you/projects/foo","prompt":"Run the tests"}}
-{"id":"5","cmd":"waitForSessionStatus","args":{"sessionId":"<from response 4>","statuses":["idle","error"],"timeout":120}}
+{"id":"4","cmd":"startSession","args":{"machineId":"MACHINE_ID","directory":"/Users/you/projects/foo","prompt":"Run the tests"}}
+{"id":"5","cmd":"waitForSessionStatus","args":{"sessionId":"SESSION_ID","statuses":["idle","error"],"timeout":120}}
 {"id":"6","cmd":"snapshot"}
 {"id":"7","cmd":"quit"}
 EOF
 ```
 
+`MACHINE_ID` comes from the `machines[].machineId` field in response 3.
 `startSession` returns `{sessionId: "..."}` in its `result`, so a
 real driver script reads that out of `harness_response` for `id:"4"`
-and substitutes it into `id:"5"`'s args.
+and substitutes it into `id:"5"`'s args as `SESSION_ID`.
 
 ## Legacy env-var smoke test
 

--- a/client/swift/project.yml
+++ b/client/swift/project.yml
@@ -42,6 +42,13 @@ targets:
         # the previously-stored JWT no longer matches, and macOS pops
         # "allow / deny" on every launch. CI overrides this back to
         # empty for the GitHub runner (no Apple cert available).
+        #
+        # Forks: replace Q2U8K9N3BL with your own team ID (visible in
+        # your Apple Developer account) and pass `CCC_EXPECTED_TEAM` to
+        # scripts/build-app.sh, or update the default in that script.
+        # The same team is currently used for both macOS and iOS configs;
+        # if you ever distribute the iOS app under a different team,
+        # scope this setting per-platform via `targets.CCCommander.platforms`.
         DEVELOPMENT_TEAM: Q2U8K9N3BL
         CODE_SIGN_STYLE: Automatic
       configs:

--- a/client/swift/scripts/build-app.sh
+++ b/client/swift/scripts/build-app.sh
@@ -8,54 +8,71 @@
 # other invocation that passes DEVELOPMENT_TEAM= or CODE_SIGN_IDENTITY=-
 # will produce an unsigned binary, which makes the macOS Keychain ACL on
 # your stored JWT mismatch and prompt for "allow / deny" on every launch.
+#
+# Forks: override the expected team via `CCC_EXPECTED_TEAM=YOURTEAM ./scripts/build-app.sh`
+# (and update project.yml to match).
 
 set -euo pipefail
 
-# Resolve the swift project dir relative to this script so callers can
-# run it from anywhere.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SWIFT_DIR="$(dirname "$SCRIPT_DIR")"
-EXPECTED_TEAM="Q2U8K9N3BL"
+EXPECTED_TEAM="${CCC_EXPECTED_TEAM:-Q2U8K9N3BL}"
 
 cd "$SWIFT_DIR"
 
-# Build with no signing override flags. xcodebuild picks up the
-# DEVELOPMENT_TEAM and CODE_SIGN_STYLE = Automatic baked into project.yml
-# (and from there into the regenerated .xcodeproj).
-echo "→ Building CCCommander_macOS (signed with team $EXPECTED_TEAM)…" >&2
+# Ask xcodebuild where it WILL put the build product *before* building.
+# This is the authoritative answer -- the alternative is scanning
+# DerivedData for the newest CCCommander.app, which races against
+# parallel builds and second-resolution mtimes. The DerivedData hash
+# depends on the absolute project path, so each worktree gets its own
+# directory; -showBuildSettings reveals the right one for THIS worktree
+# without us having to guess.
+BUILD_DIR=$(xcodebuild -showBuildSettings \
+    -project CCCommander.xcodeproj \
+    -scheme CCCommander_macOS \
+    -destination 'platform=macOS' \
+    2>/dev/null \
+  | awk -F' = ' '/^[[:space:]]*BUILT_PRODUCTS_DIR / {print $2; exit}')
+
+if [[ -z "$BUILD_DIR" ]]; then
+  echo "✗ failed to read BUILT_PRODUCTS_DIR from xcodebuild -showBuildSettings" >&2
+  echo "  Run \`xcodebuild -showBuildSettings -project CCCommander.xcodeproj -scheme CCCommander_macOS\` manually to debug." >&2
+  exit 1
+fi
+APP="$BUILD_DIR/CCCommander.app"
+
+# Run the build. `-quiet` suppresses informational output (per-target
+# compile commands, dependency graph dumps) but Apple's documentation
+# is explicit that errors and warnings still go to stderr -- so a
+# compile failure is visible AND `set -e` aborts the script at that
+# point. Without -quiet, a clean build dumps ~200 KB of chatter.
+echo "→ Building CCCommander_macOS (signing for team $EXPECTED_TEAM)…" >&2
 xcodebuild build \
   -project CCCommander.xcodeproj \
   -scheme CCCommander_macOS \
   -destination 'platform=macOS' \
   -quiet >&2
 
-# Find the most recently-built .app under DerivedData. The hash in the
-# DerivedData directory name depends on the absolute project path, so
-# different worktrees produce different paths -- always pick the newest.
-# Use -print0 / -exec to be safe with paths containing spaces or newlines.
-APP=$(find ~/Library/Developer/Xcode/DerivedData \
-        -maxdepth 6 \
-        -path '*CCCommander*/Build/Products/Debug/CCCommander.app' \
-        -exec stat -f '%m %N' {} + 2>/dev/null \
-      | sort -rn \
-      | head -1 \
-      | cut -d' ' -f2-)
-
-if [[ -z "$APP" || ! -d "$APP" ]]; then
-  echo "✗ build succeeded but no CCCommander.app was found under DerivedData" >&2
+if [[ ! -d "$APP" ]]; then
+  echo "✗ build reported success but $APP doesn't exist" >&2
   exit 1
 fi
 
-# Verify the signature is the stable team. If it's `not set`, the
-# binary is ad-hoc and will trigger a keychain prompt on launch --
-# bail loudly so the user notices instead of stumbling into the
-# prompt at runtime.
-ACTUAL_TEAM=$(codesign -dvv "$APP" 2>&1 | awk -F= '/^TeamIdentifier=/ {print $2}')
+# Verify the signature. If `codesign` itself fails (file not signed at
+# all, missing tool), we want a distinct error from "team mismatch" so
+# split the exit-code check from the team-name check.
+if ! CODESIGN_OUT=$(codesign -dvv "$APP" 2>&1); then
+  echo "✗ codesign failed on $APP:" >&2
+  printf '    %s\n' "${CODESIGN_OUT//$'\n'/$'\n    '}" >&2
+  exit 2
+fi
+ACTUAL_TEAM=$(printf '%s\n' "$CODESIGN_OUT" | awk -F= '/^TeamIdentifier=/ {print $2}')
 if [[ "$ACTUAL_TEAM" != "$EXPECTED_TEAM" ]]; then
   echo "✗ binary at $APP is signed with team '$ACTUAL_TEAM', expected '$EXPECTED_TEAM'" >&2
   echo "  This will trigger a macOS Keychain prompt on launch." >&2
   echo "  Check that project.yml has DEVELOPMENT_TEAM = $EXPECTED_TEAM" >&2
   echo "  and that nothing in your shell environment overrides it." >&2
+  echo "  (To override the expected team for a fork, set CCC_EXPECTED_TEAM.)" >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary

Retrospective review pass on the parts of #66 that didn't get a proper second-eyes review before merge. Reviewer agent flagged real issues; this PR addresses them.

- **scripts/build-app.sh**: replace fragile DerivedData scan with `xcodebuild -showBuildSettings BUILT_PRODUCTS_DIR` (kills race conditions, HOME assumptions, and second-resolution mtime collisions in one shot). Make `EXPECTED_TEAM` overridable via `CCC_EXPECTED_TEAM` for forks. Split codesign exit-check from team-name check so a missing tool produces a distinct error from "team mismatch".
- **project.yml**: add fork-friendly comment explaining how to swap the team ID + how to scope per-platform if iOS ever needs a different team.
- **TESTING.md**: fix numbered list (`# 2.` → `# 4.` jump after my earlier edit), replace literal `<from snapshot>` placeholders with `MACHINE_ID`/`SESSION_ID` sentinels + warning that the block isn't valid JSON as-is, add a **Collaborative debugging mode** subsection (the harness and SwiftUI GUI share the same `@MainActor AppState` when launched with `CC_COMMANDER_CMD_FILE` — this was the actual value of the work in #66 and the doc didn't capture it).
- **CLAUDE.md**: reflect new BUILT_PRODUCTS_DIR approach + document the env-var override.

## Test plan

- [x] \`swift test\` — 96/96 pass
- [x] \`./scripts/build-app.sh\` — clean run, signed Q2U8K9N3BL
- [x] \`CCC_EXPECTED_TEAM=WRONG ./scripts/build-app.sh\` — fails with exit code 2, error message references the override env var
- [x] \`shellcheck scripts/build-app.sh\` — no issues (pre-commit hook also runs this)
- [ ] Manual: read TESTING.md fresh and run the GUI quickstart top-to-bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)