### PR TITLE
Bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           - workspace: runner
             package: cc-commander-runner
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -47,7 +47,7 @@ jobs:
     # and the iOS-specific code is a small set of SwiftUI #if os(iOS) blocks.
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select Xcode 16
         run: sudo xcode-select -s /Applications/Xcode_16.app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
     name: Hub tests (gate)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -60,7 +60,7 @@ jobs:
     outputs:
       version: ${{ steps.meta.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Compute VERSION + image tags
         id: meta
@@ -88,9 +88,9 @@ jobs:
               echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Build & push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           # Build context is the repo root because hub depends on the
           # workspace package @cc-commander/protocol (sibling directory).
@@ -154,7 +154,7 @@ jobs:
 
       - name: SSH deploy
         if: steps.gate.outputs.skip != 'true'
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@v1.2.5
         env:
           DEPLOY_HUB_DIR: ${{ secrets.DEPLOY_HUB_DIR }}
         with:


### PR DESCRIPTION
## Summary

GitHub deprecated Node 20 actions on 2025-09-19 and removes them from runners on **2026-09-16**. Every workflow run is currently spamming deprecation annotations. Bump all affected actions to current latest majors:

| Action | Old | New |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/build-push-action | v6 | v7 |
| appleboy/ssh-action | v1.2.0 | v1.2.5 |

All majors are documented as drop-in for the way we use them — `checkout`/`setup-node` only take node-version + cache inputs, the docker actions take the same inputs we pass today, and `ssh-action` is a patch bump.

## Test plan

This PR exercises both workflows end-to-end on first push:
- [ ] CI (ci.yml): hub/runner/protocol Node tests + Swift macOS build
- [ ] Release (release.yml): hub-image build+push + deploy to VPS + verify
- [ ] Deprecation annotations no longer appear

If anything breaks, the failure is immediate and visible — no surprise mid-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)