### PR TITLE
docs: SECURITY.md + Tailscale deployment recipe

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -9,7 +9,132 @@ This walks through a real three-machine deployment:
 You can run all three on the same machine for testing — see the "Local
 all-in-one" section at the bottom.
 
+See [`SECURITY.md`](SECURITY.md) for the threat model before choosing
+between the two deployment paths below.
+
 ---
+
+## Recommended: Tailscale-only deployment (personal use)
+
+This is the recommended deployment for personal / solo use. It is
+significantly safer than exposing the hub on the public internet: the
+hub is unreachable except from devices on your tailnet, which kills
+mass scanning, credential stuffing, brute force, and any external
+0-day against the hub's HTTP / WebSocket surface in one shot.
+
+Residual risk after this deployment is concentrated in the supply
+chain (GitHub, npm, the Claude Agent SDK). That is tracked separately
+in [`SECURITY.md`](SECURITY.md).
+
+### 1. Install Tailscale everywhere
+
+- On the **hub VPS**: follow the Tailscale Linux instructions,
+  `sudo tailscale up`, and note the resulting tailnet IP (e.g.
+  `100.64.0.5`) and MagicDNS name (e.g. `hub.tail1234.ts.net`).
+- On each **runner machine** (Mac Mini, MacBook, ...): install the
+  Tailscale app (or `brew install --cask tailscale`), sign in, and
+  confirm the device shows up in the admin console.
+- On each **client device** (iPhone, Mac laptop, ...): install the
+  Tailscale app from the App Store, sign in, and confirm it can ping
+  the hub's tailnet IP.
+
+### 2. Run the hub bound to the tailnet only
+
+Two options, pick one.
+
+**Option A (simplest): bind the container to the tailnet IP.**
+Edit `hub/docker-compose.yml` and change the port mapping from
+`127.0.0.1:3000:3000` to your tailnet IP, e.g. `100.64.0.5:3000:3000`.
+Start the hub with `docker compose up -d`. Skip the reverse proxy
+step in the alternative section entirely. No TLS, no public DNS, no
+Caddy, no nginx. The hub is reachable only from devices on your
+tailnet, over WireGuard.
+
+**Option B (cleanest, with TLS): `tailscale serve`.** Leave the
+compose file bound to `127.0.0.1:3000` and put Tailscale in front of
+it:
+
+```sh
+sudo tailscale serve --bg --https=443 http://127.0.0.1:3000
+```
+
+This gives you a real HTTPS endpoint at
+`https://hub.tail1234.ts.net` with a free cert provisioned by
+`tailscale cert`, reachable only from your tailnet. WebSocket
+upgrades work out of the box. You do not need Caddy or nginx.
+
+### 3. Point the client app at the hub's MagicDNS name
+
+Use the MagicDNS name, not the raw tailnet IP, so the Tailscale cert
+(option B) validates and so the URL keeps working if the VPS is
+recreated.
+
+```sh
+# Option A, no TLS
+defaults write com.cc-commander.app HubBaseURL http://hub.tail1234.ts.net:3000
+
+# Option B, tailscale serve with TLS
+defaults write com.cc-commander.app HubBaseURL https://hub.tail1234.ts.net
+```
+
+iOS: bake the URL into the build (see "Option B" under the macOS
+client app section below) since there is no defaults trick for a
+device build yet.
+
+### 4. Register runners the same way, using the tailnet URL
+
+```sh
+node --experimental-strip-types src/cli.ts register \
+    --hub https://hub.tail1234.ts.net \
+    --email you@example.com \
+    --name "mac-mini-living-room"
+```
+
+Everything else in the "Runner on a Mac" section below still applies.
+
+### 5. Optional: lock it down with Tailscale ACLs
+
+By default every device on your tailnet can talk to every other
+device on every port. You can tighten this so that only your client
+devices can reach the hub's port 443, and runners are only allowed
+to egress to the hub (not to each other, not to clients). Edit your
+tailnet policy in the Tailscale admin console:
+
+```json
+{
+  "tagOwners": {
+    "tag:hub":    ["autogroup:admin"],
+    "tag:runner": ["autogroup:admin"],
+    "tag:client": ["autogroup:admin"]
+  },
+  "acls": [
+    { "action": "accept", "src": ["tag:client"], "dst": ["tag:hub:443"] },
+    { "action": "accept", "src": ["tag:runner"], "dst": ["tag:hub:443"] }
+  ]
+}
+```
+
+Tag each device accordingly in the admin console. Clients can reach
+the hub, runners can reach the hub, nothing else can reach anything.
+
+### 6. Optional: enable tailnet lock
+
+For the paranoid: turn on tailnet lock in the Tailscale admin console
+so that new nodes joining your tailnet must be signed by an existing
+trusted node. This prevents a compromised Tailscale control plane
+from silently adding a new device to your tailnet.
+
+---
+
+## Alternative: public hub on a VPS (advanced)
+
+> Warning: this path significantly increases attack surface. A public
+> hub is exposed to mass scanning, credential stuffing, and any
+> external 0-day against the hub's HTTP / WebSocket surface. Only use
+> it if you know what you are doing, set a strong unique password, and
+> are prepared to keep up with the hardening tracker in
+> [`SECURITY.md`](SECURITY.md). For personal use, prefer the
+> Tailscale-only deployment above.
 
 ## 1. Hub on a VPS
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -83,6 +83,19 @@ device build yet.
 
 ### 4. Register runners the same way, using the tailnet URL
 
+Use whichever scheme matches the option you picked above. With
+Option A (no TLS) the hub speaks plain HTTP on port 3000:
+
+```sh
+node --experimental-strip-types src/cli.ts register \
+    --hub http://hub.tail1234.ts.net:3000 \
+    --email you@example.com \
+    --name "mac-mini-living-room"
+```
+
+With Option B (`tailscale serve` with TLS) the hub is reachable
+over HTTPS on the default port:
+
 ```sh
 node --experimental-strip-types src/cli.ts register \
     --hub https://hub.tail1234.ts.net \
@@ -96,9 +109,11 @@ Everything else in the "Runner on a Mac" section below still applies.
 
 By default every device on your tailnet can talk to every other
 device on every port. You can tighten this so that only your client
-devices can reach the hub's port 443, and runners are only allowed
-to egress to the hub (not to each other, not to clients). Edit your
-tailnet policy in the Tailscale admin console:
+devices can reach the hub, and runners are only allowed to egress
+to the hub (not to each other, not to clients). Edit your tailnet
+policy in the Tailscale admin console. The example below uses
+`tag:hub:443` (Option B); if you went with Option A, swap the two
+`dst` entries to `tag:hub:3000`.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ See [`DEPLOY.md`](DEPLOY.md) for an end-to-end guide: hub on a VPS,
 runner on a Mac, client app on your laptop. There's also a
 "local all-in-one" section if you just want to try it on one machine.
 
+See [`SECURITY.md`](SECURITY.md) for the threat model and recommended deployment.
+
 ## Repository
 
 Monorepo. Each component builds, tests, and deploys independently. They share no runtime code -- they communicate only over the network.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,114 @@
+# Security
+
+CC Commander gives Claude full shell access on every machine where a runner
+is installed. A valid hub JWT is, functionally, an SSH key to all of your
+linked machines. The runner launches Claude with `permissionMode:
+"bypassPermissions"` and `allowDangerouslySkipPermissions: true`. This is
+intentional (yolo mode is the whole point), but it means the security of
+your machines collapses to the security of your hub account.
+
+The trust level is simple: if you can authenticate to the hub, you can run
+any command on any runner attached to that account.
+
+## Who this is for
+
+Solo developers willing to self-host. One person, their own hub, their own
+runners.
+
+It is **not** recommended as a multi-tenant hosted service, and it is
+**not** suitable for shared or corporate environments without significant
+additional hardening that is out of scope for this project.
+
+If you are not comfortable running something that has SSH-equivalent
+authority over your machines, do not run CC Commander.
+
+## What we defend against
+
+- **Mass internet scanning and credential stuffing.** Primary defense:
+  the recommended deployment keeps the hub on a Tailscale-only VPS with
+  no public DNS and no reverse proxy, so scanners cannot reach it at all.
+  See the "Recommended: Tailscale-only deployment" section in
+  [`DEPLOY.md`](DEPLOY.md).
+- **Brute force on hub login.** Defense: rate limiting on
+  `/api/auth/login`. Hardware-key 2FA is planned (see tracker issues
+  below).
+- **Stolen long-lived runner registration tokens.** Current defense: the
+  token file is written mode `0600` under `~/.config/cc-commander/`, and
+  compromise is contained to one machine because each runner has its own
+  token. Rotation and short-lived tokens are planned.
+- **Supply chain compromise via npm install scripts.** Planned defense:
+  `npm ci --ignore-scripts` in the runner self-update path, tracked in
+  the hardening issues below.
+- **GitHub maintainer account compromise leading to a malicious update
+  rolling out to runners.** Planned defense: signed git tags (hardware
+  key), plus manual operator approval for runner self-updates. Tracked
+  below.
+
+## What we explicitly do NOT defend against
+
+- **The yolo runner itself.** Once a session starts, Claude can run any
+  command the runner user can run. This is by design. Do not install a
+  runner under a user account you are not willing to give away.
+- **Prompt injection of Claude.** Same risk profile as running Claude
+  Code locally: a hostile repo, a hostile web page pulled into context,
+  or a hostile MCP server can steer the session. CC Commander does not
+  add or remove that risk.
+- **Physical access to an unlocked client device.** If your phone is
+  unlocked and in someone else's hand, they have your hub.
+- **State-level adversaries** with the ability to MITM Tailscale's
+  control plane, compromise GitHub at the platform level, or subvert
+  the Claude Agent SDK upstream. These are explicitly out of scope.
+
+## Recommended deployment (for the maintainer)
+
+The deployment the maintainer actually uses, and the one you should use
+if you self-host:
+
+- Hub on a Tailscale-only VPS. No public DNS record for the hub, no
+  Caddy / nginx / Traefik, no port 443 exposed to the internet. The
+  full walkthrough is in [`DEPLOY.md`](DEPLOY.md) under "Recommended:
+  Tailscale-only deployment".
+- Strong, unique hub password. Long (20+ chars) and stored in a
+  password manager, not reused anywhere else.
+- Runners installed only under user accounts you would be willing to
+  hand an attacker.
+- Once it lands: hardware-key (Yubikey) signed git tags, with runner
+  self-update verifying signatures before applying.
+- Once it lands: `npm ci --ignore-scripts` in the runner self-update
+  path, so a malicious dep cannot execute during install.
+- Once it lands: manual operator approval for runner self-updates
+  (push notification to the client app, operator taps "apply").
+
+Until those hardening items land, the supply chain (GitHub, npm, the
+Claude Agent SDK) is where the concentrated residual risk lives. Treat
+it accordingly.
+
+## Reporting vulnerabilities
+
+Email `security@TODO` (maintainer: replace this placeholder with a real
+address before publishing). Please do not file public issues for
+vulnerabilities that would let an attacker reach a runner.
+
+There is no bug bounty. This is a personal project, maintained
+best-effort. Response times are whatever the maintainer can manage
+around a day job. Thank you for reporting anyway.
+
+## Known limitations and unfixed risks
+
+These are tracked as issues in the hardening tracker. Numbers below are
+placeholders that the maintainer will replace with real issue numbers.
+
+- `#TODO-tailscale`: document and default to Tailscale-only deployment
+  (partially addressed by this file and `DEPLOY.md`).
+- `#TODO-signed-tags`: hardware-key signed git tags, with runner-side
+  signature verification before self-update.
+- `#TODO-ignore-scripts`: switch the runner self-update to `npm ci
+  --ignore-scripts`, audit which packages actually need postinstall.
+- `#TODO-manual-update-approval`: require explicit operator approval
+  in the client app before a runner applies a pending self-update.
+- `#TODO-token-rotation`: short-lived registration tokens with
+  rotation, so a stolen `runner.json` expires on its own.
+- `#TODO-2fa`: hardware-key 2FA on hub login.
+
+If you find a hardening gap that is not on this list, please report it
+(see above).


### PR DESCRIPTION
## Summary

- New `SECURITY.md` at repo root: plainly states the threat model (hub JWT is functionally an SSH key, runner is yolo by design), who this is for (solo self-hosters, not multi-tenant), what we defend against vs explicitly do not, recommended deployment for the maintainer, vuln reporting, and a known-limitations list linked to hardening tracker issues.
- `DEPLOY.md`: new top-level "Recommended: Tailscale-only deployment (personal use)" section before the existing VPS path. Walks through Tailscale install, two options for binding the hub (tailnet IP vs `tailscale serve` with free TLS), client config, ACL example, and optional tailnet lock. The prior "1. Hub on a VPS" flow is retitled as the "Alternative: public hub on a VPS (advanced)" path with a warning callout. Existing reverse-proxy / env / account-creation / runner / client sections are untouched.
- `README.md`: one-line pointer to `SECURITY.md` from the "Running it" section.

No code changes. Tests (`npm test`) and `npm run typecheck` pass locally.

## TODOs for the maintainer before merging or shortly after

- Replace `security@TODO` in `SECURITY.md` with a real reporting address.
- File the hardening tracker issues and replace the `#TODO-tailscale`, `#TODO-signed-tags`, `#TODO-ignore-scripts`, `#TODO-manual-update-approval`, `#TODO-token-rotation`, `#TODO-2fa` placeholders with real issue numbers.
- Swap the example tailnet hostnames (`hub.tail1234.ts.net`, `100.64.0.5`) for your real values if you want the docs to copy-paste cleanly.

## Test plan

- [ ] Skim `SECURITY.md` for tone / accuracy, fill in the security email and issue numbers.
- [ ] Walk through the Tailscale recipe end-to-end on a throwaway VPS to confirm the two options (bind-to-tailnet-IP and `tailscale serve`) actually work as written.
- [ ] Confirm the retitled "Alternative: public hub on a VPS" section still reads cleanly top-to-bottom.

Generated with Claude Code.