### PR TITLE
feat: panic button to revoke all account sessions (#88)

### DIFF
--- a/client/swift/CCCommander/Views/Sessions/SessionListView.swift
+++ b/client/swift/CCCommander/Views/Sessions/SessionListView.swift
@@ -7,6 +7,7 @@ struct SessionListView: View {
     @State private var showingNewSession = false
     @State private var filterStatus: SessionStatus?
     @State private var filterMachine: String?
+    @State private var showingPanicConfirm = false
 
     var filteredSessions: [SessionMeta] {
         appState.sortedSessions.filter { session in
@@ -61,9 +62,29 @@ struct SessionListView: View {
                 }
             }
             #endif
+
+            ToolbarItem(placement: .automatic) {
+                Menu {
+                    Button("Panic: Kick All Devices", systemImage: "exclamationmark.triangle.fill", role: .destructive) {
+                        showingPanicConfirm = true
+                    }
+                } label: {
+                    Label("Account", systemImage: "person.circle")
+                }
+            }
         }
         .sheet(isPresented: $showingNewSession) {
             NewSessionSheet()
+        }
+        .confirmationDialog(
+            "Revoke all sessions?",
+            isPresented: $showingPanicConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Kick All Devices", role: .destructive) { triggerPanic() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will sign out every client and runner on your account and revoke all stored tokens. You will need to sign back in.")
         }
         .overlay {
             if filteredSessions.isEmpty {
@@ -96,6 +117,16 @@ struct SessionListView: View {
                 try await appState.archiveSession(sessionId: session.sessionId)
             } catch {
                 appState.recordError("Failed to archive session: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func triggerPanic() {
+        Task {
+            do {
+                try await appState.panic()
+            } catch {
+                appState.recordError("Panic failed: \(error.localizedDescription)")
             }
         }
     }

--- a/client/swift/CCCommanderPackage/Sources/CCApp/AppState.swift
+++ b/client/swift/CCCommanderPackage/Sources/CCApp/AppState.swift
@@ -123,6 +123,13 @@ public final class AppState {
         try await connection.archiveSession(sessionId: sessionId)
     }
 
+    /// Panic button: revoke all tokens and kick all sessions on this
+    /// account. Forwards to `HubConnection.panic()`, which also calls
+    /// `logout()` so local state returns to the auth screen on success.
+    public func panic() async throws {
+        try await connection.panic()
+    }
+
     public func recordError(_ message: String) {
         lastError = HubErrorToast(message: message)
     }

--- a/client/swift/CCCommanderPackage/Sources/CCApp/TestCommandRunner.swift
+++ b/client/swift/CCCommanderPackage/Sources/CCApp/TestCommandRunner.swift
@@ -228,6 +228,10 @@ public final class TestCommandRunner {
             await harness.logout()
             return ["state": "disconnected"]
 
+        case "panic":
+            try await harness.panic()
+            return ["state": "disconnected"]
+
         case "startSession":
             let machineId = try requiredString(args, "machineId")
             let directory = try requiredString(args, "directory")

--- a/client/swift/CCCommanderPackage/Sources/CCApp/TestHarness.swift
+++ b/client/swift/CCCommanderPackage/Sources/CCApp/TestHarness.swift
@@ -41,6 +41,12 @@ public final class TestHarness {
         logResult("logout", ok: true)
     }
 
+    public func panic() async throws {
+        log("panic")
+        try await appState.panic()
+        logResult("panic", ok: true)
+    }
+
     // MARK: - Session control
 
     public func startSession(machineId: String, directory: String, prompt: String) async throws {

--- a/client/swift/CCCommanderPackage/Sources/CCNetworking/AuthClient.swift
+++ b/client/swift/CCCommanderPackage/Sources/CCNetworking/AuthClient.swift
@@ -16,6 +16,9 @@ public protocol AuthClientProtocol: Sendable {
     func login(email: String, password: String) async throws -> TokenPair
     func register(email: String, password: String) async throws -> TokenPair
     func refresh(refreshToken: String) async throws -> TokenPair
+    /// Panic button: revoke all refresh tokens and kick all sessions for
+    /// the caller's account. Expects HTTP 204 on success.
+    func panic(token: String) async throws
 }
 
 /// Production auth client using URLSession.
@@ -38,6 +41,22 @@ public struct AuthClient: AuthClientProtocol {
 
     public func refresh(refreshToken: String) async throws -> TokenPair {
         try await post(path: "/api/auth/refresh", body: RefreshRequest(refreshToken: refreshToken))
+    }
+
+    public func panic(token: String) async throws {
+        let url = baseURL.appendingPathComponent("/api/auth/panic")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw AuthError.invalidResponse
+        }
+        guard http.statusCode == 204 else {
+            let errorBody = try? JSONDecoder().decode(AuthErrorResponse.self, from: data)
+            throw AuthError.serverError(http.statusCode, errorBody?.error ?? "Unknown error")
+        }
     }
 
     private func post<T: Encodable>(path: String, body: T) async throws -> TokenPair {
@@ -106,5 +125,13 @@ public actor MockAuthClient: AuthClientProtocol {
     public func refresh(refreshToken: String) async throws -> TokenPair {
         refreshCallCount += 1
         return try refreshResult.get()
+    }
+
+    public var panicResult: Result<Void, Error> = .success(())
+    public private(set) var panicCallCount = 0
+
+    public func panic(token: String) async throws {
+        panicCallCount += 1
+        try panicResult.get()
     }
 }

--- a/client/swift/CCCommanderPackage/Sources/CCNetworking/HubConnection.swift
+++ b/client/swift/CCCommanderPackage/Sources/CCNetworking/HubConnection.swift
@@ -140,6 +140,21 @@ public final class HubConnection {
         state = .disconnected
     }
 
+    /// Panic: POST /api/auth/panic with the current JWT, then clear
+    /// local tokens and drop the connection. The hub will have already
+    /// closed the WebSocket with code 4003 by the time this returns, so
+    /// `logout()` is the clean-up path: it clears the keychain and
+    /// resets state so the UI bounces back to the login screen.
+    public func panic() async throws {
+        guard let token = keychain.jwt else {
+            log.error("panic called with no stored jwt")
+            throw HubConnectionError.noStoredTokens
+        }
+        log.warn("panic triggered by user")
+        try await authClient.panic(token: token)
+        await logout()
+    }
+
     // MARK: - Commands
 
     public func startSession(machineId: String, directory: String, prompt: String) async throws {

--- a/hub/src/__tests__/hub.test.ts
+++ b/hub/src/__tests__/hub.test.ts
@@ -1859,3 +1859,145 @@ describe("session lifecycle in DB", () => {
     assert.equal(recovered.endedAt, null);
   });
 });
+
+// ── Panic button (/api/auth/panic) ──────────────────────────────────────
+
+describe("POST /api/auth/panic", () => {
+  // Prevents: unauthenticated callers nuking someone else's sessions
+  it("returns 401 without a bearer token", async () => {
+    const res = await fetch(`${baseUrl}/api/auth/panic`, { method: "POST" });
+    assert.equal(res.status, 401);
+  });
+
+  // Prevents: panic button silently failing for a valid caller
+  it("returns 204 with a valid bearer token", async () => {
+    const tokens = await auth.register("panic1@test.com", "password");
+    const res = await fetch(`${baseUrl}/api/auth/panic`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tokens.token}` },
+    });
+    assert.equal(res.status, 204);
+  });
+
+  // Prevents: a compromised device refreshing its way back in after panic
+  it("deletes every refresh token for the caller's account", async () => {
+    const tokens = await auth.register("panic2@test.com", "password");
+    const accountId = auth.verifyToken(tokens.token).accountId;
+    // Mint a second refresh token so we're sure ALL are wiped, not just one.
+    db.createRefreshToken(
+      accountId,
+      new Date(Date.now() + 86_400_000).toISOString(),
+    );
+    const res = await fetch(`${baseUrl}/api/auth/panic`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tokens.token}` },
+    });
+    assert.equal(res.status, 204);
+    assert.equal(db.getRefreshToken(tokens.refreshToken), undefined);
+  });
+
+  // Prevents: the button leaving stale client WebSockets alive
+  it("closes open client WebSockets with code 4003", async () => {
+    const tokens = await auth.register("panic3@test.com", "password");
+    const clientWs = await connectClient(tokens.token);
+    const closeCode = new Promise<number>((resolve) => {
+      clientWs.on("close", (code) => resolve(code));
+    });
+    const res = await fetch(`${baseUrl}/api/auth/panic`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tokens.token}` },
+    });
+    assert.equal(res.status, 204);
+    assert.equal(await closeCode, 4003);
+  });
+
+  // Prevents: runner for the account surviving a panic and keeping a
+  // long-lived session alive
+  it("closes open runner WebSockets for the account with code 4003", async () => {
+    const tokens = await auth.register("panic4@test.com", "password");
+    const accountId = auth.verifyToken(tokens.token).accountId;
+    const machine = db.createMachine(accountId, "lab");
+    const runnerWs = await connectRunner(machine.registrationToken);
+    const closeCode = new Promise<number>((resolve) => {
+      runnerWs.on("close", (code) => resolve(code));
+    });
+    const res = await fetch(`${baseUrl}/api/auth/panic`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tokens.token}` },
+    });
+    assert.equal(res.status, 204);
+    assert.equal(await closeCode, 4003);
+  });
+
+  // Prevents: cross-account blast radius (A hits panic, B loses sessions)
+  it("does not affect clients on a different account", async () => {
+    const a = await auth.register("panicA@test.com", "password");
+    const b = await auth.register("panicB@test.com", "password");
+    const wsB = await connectClient(b.token);
+    let bClosed = false;
+    wsB.on("close", () => {
+      bClosed = true;
+    });
+    const res = await fetch(`${baseUrl}/api/auth/panic`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${a.token}` },
+    });
+    assert.equal(res.status, 204);
+    // Give the hub a tick to propagate any (erroneous) close.
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(bClosed, false);
+    assert.equal(wsB.readyState, WebSocket.OPEN);
+    await closeWs(wsB);
+  });
+
+  // Prevents: silent panic (no metric bump means no dashboards, no audit)
+  it("increments hub.panic_triggered on success", async () => {
+    const tokens = await auth.register("panicM@test.com", "password");
+    const before = hub.metrics.snapshot()["hub.panic_triggered"] ?? 0;
+    const res = await fetch(`${baseUrl}/api/auth/panic`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tokens.token}` },
+    });
+    assert.equal(res.status, 204);
+    const after = hub.metrics.snapshot()["hub.panic_triggered"] ?? 0;
+    assert.equal(after - before, 1);
+  });
+
+  // Prevents: unbounded abuse (an attacker with a stolen JWT spamming
+  // the button to force-logout everyone else on the same account)
+  it("rate limits per-account and returns 429 past the cap", async () => {
+    await hub.stop();
+    db.close();
+    db = new HubDb(":memory:");
+    auth = new AuthService(db, JWT_SECRET);
+    hub = new Hub({
+      port: 0,
+      db,
+      auth,
+      rateLimits: {
+        login: { capacity: 100, perMinute: 100 },
+        register: { capacity: 100, perMinute: 100 },
+        machineCreate: { capacity: 100, perHour: 100 },
+        // Capacity 1, refill essentially never for the test window.
+        panic: { capacity: 1, perHour: 0.0001 },
+      },
+    });
+    await hub.start();
+    const addr = hub.httpServer.address();
+    port = typeof addr === "object" && addr ? addr.port : 0;
+    baseUrl = `http://localhost:${port}`;
+
+    const tokens = await auth.register("panicL@test.com", "password");
+    const r1 = await fetch(`${baseUrl}/api/auth/panic`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tokens.token}` },
+    });
+    const r2 = await fetch(`${baseUrl}/api/auth/panic`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tokens.token}` },
+    });
+    assert.equal(r1.status, 204);
+    assert.equal(r2.status, 429);
+    assert.equal(hub.metrics.snapshot()["hub.rate_limited{limiter=panic}"], 1);
+  });
+});

--- a/hub/src/db.ts
+++ b/hub/src/db.ts
@@ -118,6 +118,12 @@ export class HubDb {
       `CREATE INDEX IF NOT EXISTS idx_sessions_machine_resync
          ON sessions (machine_id, archived_at, last_activity DESC);`,
     );
+    // Supports the panic button's bulk delete (deleteRefreshTokensForAccount)
+    // without a table scan. Cheap even for a personal deployment.
+    this.db.exec(
+      `CREATE INDEX IF NOT EXISTS idx_refresh_tokens_account
+         ON refresh_tokens (account_id);`,
+    );
   }
 
   /**
@@ -441,8 +447,7 @@ export class HubDb {
   /**
    * Bulk revoke: drops every refresh token owned by one account. Used
    * by the panic button so a compromised device can't refresh its way
-   * back in after the user hits the kill switch. Returns rows deleted
-   * for observability (tests assert on it; production doesn't care).
+   * back in after the user hits the kill switch. Returns rows deleted.
    */
   deleteRefreshTokensForAccount(accountId: string): number {
     const result = this.db

--- a/hub/src/db.ts
+++ b/hub/src/db.ts
@@ -438,6 +438,19 @@ export class HubDb {
     this.db.prepare("DELETE FROM refresh_tokens WHERE token = ?").run(token);
   }
 
+  /**
+   * Bulk revoke: drops every refresh token owned by one account. Used
+   * by the panic button so a compromised device can't refresh its way
+   * back in after the user hits the kill switch. Returns rows deleted
+   * for observability (tests assert on it; production doesn't care).
+   */
+  deleteRefreshTokensForAccount(accountId: string): number {
+    const result = this.db
+      .prepare("DELETE FROM refresh_tokens WHERE account_id = ?")
+      .run(accountId);
+    return result.changes;
+  }
+
   close(): void {
     this.db.close();
   }

--- a/hub/src/hub.ts
+++ b/hub/src/hub.ts
@@ -17,6 +17,7 @@ import { PendingHistoryStore } from "./state/pendingHistory.ts";
 import type { ClientConnection, RunnerConnection } from "./ws/types.ts";
 import { handleAuthEndpoint, handleRefreshEndpoint } from "./routes/auth.ts";
 import { handleCreateMachine } from "./routes/machines.ts";
+import { handlePanic } from "./routes/panic.ts";
 import { handleHealth, handleVersion } from "./routes/health.ts";
 import { handleDebugState } from "./routes/debug.ts";
 import type { DebugSnapshot, RouteContext } from "./routes/types.ts";
@@ -28,6 +29,9 @@ import {
 } from "./ws/clientMessage.ts";
 import { handleRunnerMessage } from "./ws/runnerMessage.ts";
 import type { WsContext } from "./ws/context.ts";
+
+// Private close code for panic-button revocations (see panicAccount).
+const PANIC_CLOSE_CODE = 4003;
 
 export interface HubConfig {
   port: number;
@@ -66,6 +70,11 @@ export interface HubConfig {
      *  upgrades have non-zero cost (socket alloc, handshake). Default
      *  30/min/IP. */
     wsUpgrade?: { capacity: number; perMinute: number };
+    /** Per-account cap on /api/auth/panic. Default 10/hour. Intentionally
+     *  low: the button is destructive (kicks every device on the
+     *  account) and a legitimate user needs at most a handful of uses
+     *  per day. */
+    panic?: { capacity: number; perHour: number };
   };
   /**
    * Inject a Metrics instance (mostly for tests, which want a fast
@@ -108,6 +117,7 @@ export class Hub {
   machineCreateLimiter: TokenBucketRateLimiter;
   machineCreateIpLimiter: TokenBucketRateLimiter;
   wsUpgradeLimiter: TokenBucketRateLimiter;
+  panicLimiter: TokenBucketRateLimiter;
   /**
    * All limiter instances in one place so start/stop sweeping is a
    * single loop. Adding a new limiter only requires registering it
@@ -161,6 +171,10 @@ export class Hub {
       capacity: 30,
       perMinute: 30,
     };
+    const panic = config.rateLimits?.panic ?? {
+      capacity: 10,
+      perHour: 10,
+    };
     this.loginLimiter = new TokenBucketRateLimiter({
       capacity: login.capacity,
       refillPerMs: login.perMinute / 60_000,
@@ -185,6 +199,10 @@ export class Hub {
       capacity: wsUpgrade.capacity,
       refillPerMs: wsUpgrade.perMinute / 60_000,
     });
+    this.panicLimiter = new TokenBucketRateLimiter({
+      capacity: panic.capacity,
+      refillPerMs: panic.perHour / 3_600_000,
+    });
     this.limiters = [
       this.loginLimiter,
       this.registerLimiter,
@@ -192,6 +210,7 @@ export class Hub {
       this.machineCreateLimiter,
       this.machineCreateIpLimiter,
       this.wsUpgradeLimiter,
+      this.panicLimiter,
     ];
     this.metrics = config.metrics ?? new Metrics();
 
@@ -265,7 +284,9 @@ export class Hub {
       refreshLimiter: this.refreshLimiter,
       machineCreateLimiter: this.machineCreateLimiter,
       machineCreateIpLimiter: this.machineCreateIpLimiter,
+      panicLimiter: this.panicLimiter,
       broadcastMachineList: (accountId) => this.broadcastMachineList(accountId),
+      panicAccount: (accountId) => this.panicAccount(accountId),
       version: this.config.version ?? "",
       // Debug endpoint reads live state directly off the Hub. Closure
       // (rather than passing the Hub class) keeps routes/ from
@@ -327,6 +348,9 @@ export class Hub {
     }
     if (req.method === "POST" && url.pathname === "/api/auth/refresh") {
       return handleRefreshEndpoint(ctx, req, res);
+    }
+    if (req.method === "POST" && url.pathname === "/api/auth/panic") {
+      return handlePanic(ctx, req, res);
     }
     if (req.method === "POST" && url.pathname === "/api/machines") {
       return handleCreateMachine(ctx, req, res);
@@ -603,6 +627,43 @@ export class Hub {
     this.relayToClients(accountId, {
       type: "machine_list",
       machines: this.enrichedMachineList(accountId),
+    });
+  }
+
+  /**
+   * Destructive account-wide session kill. Deletes every refresh
+   * token and closes every open client/runner WebSocket for the
+   * account with close code 4003. Private so routes/ never see the
+   * raw WebSocket map; exposed via the `panicAccount` closure on
+   * RouteContext, matching the `broadcastMachineList` pattern.
+   */
+  private panicAccount(accountId: string): void {
+    const refreshDeleted =
+      this.config.db.deleteRefreshTokensForAccount(accountId);
+
+    // Snapshot to an array before closing: each ws.close() triggers
+    // the 'close' handler synchronously on some ws paths which calls
+    // removeClient and mutates the underlying Set, breaking mid-loop
+    // iteration otherwise.
+    const clientBucket = this.clientsByAccount.get(accountId);
+    const clients = clientBucket ? Array.from(clientBucket) : [];
+    for (const conn of clients) {
+      conn.ws.close(PANIC_CLOSE_CODE, "Revoked by panic");
+    }
+
+    const runners: RunnerConnection[] = [];
+    for (const conn of this.runners.values()) {
+      if (conn.accountId === accountId) runners.push(conn);
+    }
+    for (const conn of runners) {
+      conn.ws.close(PANIC_CLOSE_CODE, "Revoked by panic");
+    }
+
+    this.log.warn("panic triggered", {
+      accountId,
+      refreshTokensDeleted: refreshDeleted,
+      clientsClosed: clients.length,
+      runnersClosed: runners.length,
     });
   }
 

--- a/hub/src/hub.ts
+++ b/hub/src/hub.ts
@@ -30,9 +30,6 @@ import {
 import { handleRunnerMessage } from "./ws/runnerMessage.ts";
 import type { WsContext } from "./ws/context.ts";
 
-// Private close code for panic-button revocations (see panicAccount).
-const PANIC_CLOSE_CODE = 4003;
-
 export interface HubConfig {
   port: number;
   db: HubDb;
@@ -648,7 +645,7 @@ export class Hub {
     const clientBucket = this.clientsByAccount.get(accountId);
     const clients = clientBucket ? Array.from(clientBucket) : [];
     for (const conn of clients) {
-      conn.ws.close(PANIC_CLOSE_CODE, "Revoked by panic");
+      conn.ws.close(4003, "Revoked by panic");
     }
 
     const runners: RunnerConnection[] = [];
@@ -656,7 +653,7 @@ export class Hub {
       if (conn.accountId === accountId) runners.push(conn);
     }
     for (const conn of runners) {
-      conn.ws.close(PANIC_CLOSE_CODE, "Revoked by panic");
+      conn.ws.close(4003, "Revoked by panic");
     }
 
     this.log.warn("panic triggered", {

--- a/hub/src/routes/panic.ts
+++ b/hub/src/routes/panic.ts
@@ -1,0 +1,50 @@
+/**
+ * POST /api/auth/panic handler. Revokes every refresh token and
+ * closes every open client/runner WebSocket owned by the caller's
+ * account. Destructive work lives behind `ctx.panicAccount`, a
+ * closure over the Hub; this route stays thin so the route layer
+ * doesn't have to know about WebSocket internals.
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { HUB_METRIC } from "@cc-commander/protocol/metrics";
+import type { JwtPayload } from "../auth.ts";
+import { extractBearerToken } from "../util/http.ts";
+import type { RouteContext } from "./types.ts";
+
+export async function handlePanic(
+  ctx: RouteContext,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const token = extractBearerToken(req);
+  let payload: JwtPayload;
+  try {
+    if (!token) throw new Error("Unauthorized");
+    payload = ctx.auth.verifyToken(token);
+  } catch {
+    res.writeHead(401);
+    res.end(JSON.stringify({ error: "Unauthorized" }));
+    return;
+  }
+
+  if (!ctx.panicLimiter.tryConsume(payload.accountId)) {
+    ctx.metrics.inc(HUB_METRIC.RATE_LIMITED, { limiter: "panic" });
+    res.writeHead(429);
+    res.end(JSON.stringify({ error: "Too many panic requests" }));
+    return;
+  }
+
+  try {
+    ctx.panicAccount(payload.accountId);
+    ctx.metrics.inc(HUB_METRIC.PANIC_TRIGGERED);
+    res.writeHead(204);
+    res.end();
+  } catch (err) {
+    ctx.log.error("panic failed", {
+      accountId: payload.accountId,
+      err: err as Error,
+    });
+    res.writeHead(500);
+    res.end(JSON.stringify({ error: "Internal error" }));
+  }
+}

--- a/hub/src/routes/types.ts
+++ b/hub/src/routes/types.ts
@@ -26,9 +26,17 @@ export interface RouteContext {
   refreshLimiter: TokenBucketRateLimiter;
   machineCreateLimiter: TokenBucketRateLimiter;
   machineCreateIpLimiter: TokenBucketRateLimiter;
+  panicLimiter: TokenBucketRateLimiter;
   /** Called after a successful machine create so the Hub can push the
    *  refreshed list to all connected clients on the owning account. */
   broadcastMachineList(accountId: string): void;
+  /**
+   * Panic button: revoke every refresh token for the account and
+   * close every open client and runner WebSocket owned by that
+   * account with code 4003. Closure (not a Hub reference) keeps
+   * routes/ decoupled from hub.ts; see `broadcastMachineList`.
+   */
+  panicAccount(accountId: string): void;
   /** Hub's version string from config (empty string if unset). */
   version: string;
   /**

--- a/protocol/src/metrics.ts
+++ b/protocol/src/metrics.ts
@@ -31,6 +31,7 @@ export const HUB_METRIC = {
   DROPPED_TOOL_BLOCK: "hub.dropped_tool_block",
   RATE_LIMITED: "hub.rate_limited",
   OVERSIZED_FRAME: "hub.oversized_frame",
+  PANIC_TRIGGERED: "hub.panic_triggered",
 } as const;
 
 export const RUNNER_METRIC = {


### PR DESCRIPTION
Closes #88.

## Summary

One tap in the macOS app revokes every token and kicks every session on the caller's account. Under the Tailscale-only personal threat model, prevention is partial by design (supply chain, account compromise). This gives you instant recovery: see something weird, tap the button, everything disconnects, you log back in fresh.

## Hub

- New \`POST /api/auth/panic\` route in \`hub/src/routes/panic.ts\`
- New private \`Hub.panicAccount\` method: bulk-deletes refresh tokens, closes all client + runner WS for the account with close code 4003 \"Revoked by panic\" (snapshot-then-iterate to avoid mid-loop mutation of \`clientsByAccount\`)
- New per-account rate limiter, default 10/hour (intentionally low; destructive action)
- New \`HUB_METRIC.PANIC_TRIGGERED\` counter
- New \`db.deleteRefreshTokensForAccount\` bulk delete

## Swift

- \`AuthClient.panic(token:)\` POST with Bearer header, expects 204
- \`HubConnection.panic()\` reads JWT, calls panic, then \`logout()\` to clear local state
- \`AppState.panic()\` forwards to connection
- \`TestHarness.panic()\` + \`TestCommandRunner\` \"panic\" command (ccc-shadow + future e2e tests)
- \`SessionListView\`: new Account toolbar menu with destructive \"Panic: Kick All Devices\" option behind a \`confirmationDialog\`

## Tests

- 8 new hub tests (all 8 required by the issue): 401 without bearer, 204 with valid bearer, refresh tokens wiped, client WS close 4003, runner WS close 4003, cross-account isolation, metric increment, rate-limit 429
- Hub: 107 → 115 passing
- Swift: 95 passing (unchanged, no new Swift tests since existing harness tests don't exercise the auth-client path directly)

## Build

- \`npm test --workspace=cc-commander-hub\`: 115/115 ✓
- \`npm run typecheck\`: clean across all three workspaces
- \`swift build\` in CCCommanderPackage: clean
- \`swift test\`: 95/95 ✓
- macOS app build via \`scripts/build-app.sh\`: clean, signs with the expected team

## Notes

This was the first Batch 2 item from the ongoing security audit. Issue #89 (signed git tags + branch protection) follows next.

Two earlier agent attempts at this PR crashed on API overloads (529). The third attempt produced most of the hub side before crashing; the Swift side was completed by hand from the surviving worktree. Nothing hacky in the result, but worth noting for session provenance.